### PR TITLE
feat: 스플래시 화면 구현

### DIFF
--- a/workguard-app/app.json
+++ b/workguard-app/app.json
@@ -33,9 +33,9 @@
           "image": "./assets/images/splash-icon.png",
           "imageWidth": 200,
           "resizeMode": "contain",
-          "backgroundColor": "#ffffff",
+          "backgroundColor": "#3182F6",
           "dark": {
-            "backgroundColor": "#000000"
+            "backgroundColor": "#3182F6"
           }
         }
       ]

--- a/workguard-app/app/_layout.tsx
+++ b/workguard-app/app/_layout.tsx
@@ -1,9 +1,14 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import * as ExpoSplashScreen from 'expo-splash-screen';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { useEffect, useState } from 'react';
 import 'react-native-reanimated';
 
+import { SplashScreen } from '@/components/splash-screen';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+
+ExpoSplashScreen.preventAutoHideAsync();
 
 export const unstable_settings = {
   anchor: '(tabs)',
@@ -11,6 +16,20 @@ export const unstable_settings = {
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    async function prepare() {
+      await ExpoSplashScreen.hideAsync();
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      setIsReady(true);
+    }
+    prepare();
+  }, []);
+
+  if (!isReady) {
+    return <SplashScreen />;
+  }
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
@@ -18,7 +37,7 @@ export default function RootLayout() {
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
       </Stack>
-      <StatusBar style="auto" />
+      <StatusBar style="light" backgroundColor="#3182F6" translucent />
     </ThemeProvider>
   );
 }

--- a/workguard-app/components/splash-screen.tsx
+++ b/workguard-app/components/splash-screen.tsx
@@ -1,0 +1,48 @@
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { Brand } from '@/constants/theme';
+
+export function SplashScreen() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.content}>
+        <Ionicons name="shield-checkmark-outline" size={80} color="white" />
+        <Text style={styles.title}>WorkGuard</Text>
+        <Text style={styles.subtitle}>Make your workplace safer</Text>
+      </View>
+      <Text style={styles.footer}>Powered by Korean Labor Standards</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Brand.primary,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingTop: 60,
+    paddingBottom: 48,
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: 'white',
+    marginTop: 4,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: 'rgba(255,255,255,0.85)',
+  },
+  footer: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.6)',
+  },
+});

--- a/workguard-app/constants/theme.ts
+++ b/workguard-app/constants/theme.ts
@@ -1,29 +1,26 @@
-/**
- * Below are the colors that are used in the app. The colors are defined in the light and dark mode.
- * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
- */
-
 import { Platform } from 'react-native';
 
-const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
+export const Brand = {
+  primary: '#3182F6',
+  background: '#F6F7F9',
+};
 
 export const Colors = {
   light: {
     text: '#11181C',
-    background: '#fff',
-    tint: tintColorLight,
+    background: Brand.background,
+    tint: Brand.primary,
     icon: '#687076',
     tabIconDefault: '#687076',
-    tabIconSelected: tintColorLight,
+    tabIconSelected: Brand.primary,
   },
   dark: {
     text: '#ECEDEE',
     background: '#151718',
-    tint: tintColorDark,
+    tint: '#fff',
     icon: '#9BA1A6',
     tabIconDefault: '#9BA1A6',
-    tabIconSelected: tintColorDark,
+    tabIconSelected: '#fff',
   },
 };
 


### PR DESCRIPTION
## 📜Description
- 피그마 디자인 기반 스플래시 화면 구현
- 앱 시작 시 파란 배경(#3182F6)에 방패 아이콘, 앱 이름, 서브타이틀이 2초간 표시된 후 메인 화면으로 전환

## ✔Checklist
 - [x] 정상적으로 빌드가 되는가?
 - [x] 로컬에서 정상적으로 실행되는가?

## 🔧Changes
- `constants/theme.ts`: Brand 컬러 토큰 추가 (primary: #3182F6, background: #F6F7F9)
- `components/splash-screen.tsx`: 스플래시 화면 UI 컴포넌트 신규 생성
- `app/_layout.tsx`: 앱 시작 시 2초간 스플래시 표시 후 메인 화면으로 전환
- `app.json`: 네이티브 스플래시 배경색 #3182F6으로 변경

## 💡Issue
- closed #3
