### PR TITLE
feat: 메인 홈 화면 구현

### DIFF
--- a/workguard-app/app/(tabs)/_layout.tsx
+++ b/workguard-app/app/(tabs)/_layout.tsx
@@ -1,35 +1,51 @@
+import { Ionicons } from '@expo/vector-icons';
 import { Tabs } from 'expo-router';
-import React from 'react';
 
 import { HapticTab } from '@/components/haptic-tab';
-import { IconSymbol } from '@/components/ui/icon-symbol';
-import { Colors } from '@/constants/theme';
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { Brand } from '@/constants/theme';
 
 export default function TabLayout() {
-  const colorScheme = useColorScheme();
-
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        tabBarActiveTintColor: Brand.primary,
+        tabBarInactiveTintColor: '#9BA1A6',
         headerShown: false,
         tabBarButton: HapticTab,
+        tabBarStyle: {
+          backgroundColor: '#fff',
+          borderTopColor: '#E5E7EB',
+        },
       }}>
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          title: '홈',
+          tabBarIcon: ({ color }) => <Ionicons name="home-outline" size={24} color={color} />,
         }}
       />
       <Tabs.Screen
-        name="explore"
+        name="contract"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          title: '계약서',
+          tabBarIcon: ({ color }) => <Ionicons name="document-text-outline" size={24} color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="salary-calendar"
+        options={{
+          title: '급여 캘린더',
+          tabBarIcon: ({ color }) => <Ionicons name="calendar-outline" size={24} color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="chatbot"
+        options={{
+          title: '챗봇',
+          tabBarIcon: ({ color }) => <Ionicons name="chatbubble-ellipses-outline" size={24} color={color} />,
+        }}
+      />
+      <Tabs.Screen name="explore" options={{ href: null }} />
     </Tabs>
   );
 }

--- a/workguard-app/app/(tabs)/chatbot.tsx
+++ b/workguard-app/app/(tabs)/chatbot.tsx
@@ -1,0 +1,39 @@
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { Brand } from '@/constants/theme';
+
+export default function ChatbotScreen() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Ionicons name="chatbubble-ellipses-outline" size={48} color="#D97706" />
+        <Text style={styles.title}>챗봇</Text>
+        <Text style={styles.desc}>준비 중입니다.</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Brand.background,
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#11181C',
+  },
+  desc: {
+    fontSize: 14,
+    color: '#687076',
+  },
+});

--- a/workguard-app/app/(tabs)/contract.tsx
+++ b/workguard-app/app/(tabs)/contract.tsx
@@ -1,0 +1,39 @@
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { Brand } from '@/constants/theme';
+
+export default function ContractScreen() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Ionicons name="document-text-outline" size={48} color={Brand.primary} />
+        <Text style={styles.title}>계약서 분석</Text>
+        <Text style={styles.desc}>준비 중입니다.</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Brand.background,
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#11181C',
+  },
+  desc: {
+    fontSize: 14,
+    color: '#687076',
+  },
+});

--- a/workguard-app/app/(tabs)/index.tsx
+++ b/workguard-app/app/(tabs)/index.tsx
@@ -1,98 +1,254 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { HelloWave } from '@/components/hello-wave';
-import ParallaxScrollView from '@/components/parallax-scroll-view';
-import { ThemedText } from '@/components/themed-text';
-import { ThemedView } from '@/components/themed-view';
-import { Link } from 'expo-router';
+import { Brand } from '@/constants/theme';
+
+const TODAY = new Date().toLocaleDateString('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const SHORTCUTS = [
+  {
+    label: '계약서 분석',
+    desc: '계약서를 사진으로 찍어\n위반 여부를 확인해요',
+    icon: 'scan-outline' as const,
+    color: Brand.primary,
+    bg: '#EBF3FF',
+    route: '/(tabs)/contract',
+  },
+  {
+    label: '급여 캘린더',
+    desc: '급여와 근무 일정을\n한눈에 관리해요',
+    icon: 'calendar-outline' as const,
+    color: '#16A34A',
+    bg: '#DCFCE7',
+    route: '/(tabs)/salary-calendar',
+  },
+  {
+    label: '챗봇',
+    desc: '노동법 관련\n궁금한 점을 물어봐요',
+    icon: 'chatbubble-ellipses-outline' as const,
+    color: '#D97706',
+    bg: '#FEF3C7',
+    route: '/(tabs)/chatbot',
+  },
+];
 
 export default function HomeScreen() {
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }>
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <Link href="/modal">
-          <Link.Trigger>
-            <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-          </Link.Trigger>
-          <Link.Preview />
-          <Link.Menu>
-            <Link.MenuAction title="Action" icon="cube" onPress={() => alert('Action pressed')} />
-            <Link.MenuAction
-              title="Share"
-              icon="square.and.arrow.up"
-              onPress={() => alert('Share pressed')}
-            />
-            <Link.Menu title="More" icon="ellipsis">
-              <Link.MenuAction
-                title="Delete"
-                icon="trash"
-                destructive
-                onPress={() => alert('Delete pressed')}
-              />
-            </Link.Menu>
-          </Link.Menu>
-        </Link>
+    <SafeAreaView style={styles.container}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}>
+        {/* Header */}
+        <View style={styles.header}>
+          <View>
+            <View style={styles.logoRow}>
+              <Ionicons name="shield-checkmark-outline" size={20} color={Brand.primary} />
+              <Text style={styles.logoText}>WorkGuard</Text>
+            </View>
+            <Text style={styles.dateText}>{TODAY}</Text>
+          </View>
+          <View style={styles.headerActions}>
+            <TouchableOpacity style={styles.iconButton}>
+              <Text style={styles.fontSizeText}>Aa</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.iconButton}>
+              <Ionicons name="notifications-outline" size={22} color="#11181C" />
+            </TouchableOpacity>
+          </View>
+        </View>
 
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+        {/* This Week Card */}
+        <View style={styles.weekCard}>
+          <Text style={styles.weekLabel}>THIS WEEK</Text>
+          <Text style={styles.weekAmount}>₩ 486,000</Text>
+          <Text style={styles.weekSub}>expected · 4 days worked</Text>
+          <View style={styles.weekDivider} />
+          <TouchableOpacity style={styles.weekRow}>
+            <Text style={styles.weekRowText}>Work on the 18th, 10 hours of rest</Text>
+            <Ionicons name="arrow-forward" size={16} color="rgba(255,255,255,0.8)" />
+          </TouchableOpacity>
+        </View>
+
+        {/* Warning Card */}
+        <TouchableOpacity style={styles.warningCard}>
+          <Ionicons name="warning-outline" size={20} color="#D97706" />
+          <View style={styles.warningContent}>
+            <Text style={styles.warningTitle}>WARNING</Text>
+            <Text style={styles.warningDesc}>Please check the precautions section.</Text>
+          </View>
+          <Ionicons name="chevron-forward" size={16} color="#D97706" />
+        </TouchableOpacity>
+
+        {/* Shortcut Grid */}
+        <View style={styles.grid}>
+          {SHORTCUTS.map(item => (
+            <TouchableOpacity
+              key={item.label}
+              style={styles.shortcutCard}
+              onPress={() => router.push(item.route as any)}>
+              <View style={[styles.shortcutIconWrap, { backgroundColor: item.bg }]}>
+                <Ionicons name={item.icon} size={24} color={item.color} />
+              </View>
+              <View style={styles.shortcutTextWrap}>
+                <Text style={styles.shortcutLabel}>{item.label}</Text>
+                <Text style={styles.shortcutDesc}>{item.desc}</Text>
+              </View>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
+  container: {
+    flex: 1,
+    backgroundColor: Brand.background,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 32,
+    gap: 24,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    paddingTop: 12,
+  },
+  logoRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: 6,
   },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
+  logoText: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#11181C',
   },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
+  dateText: {
+    fontSize: 13,
+    color: '#687076',
+    marginTop: 2,
+    marginLeft: 26,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    gap: 4,
+  },
+  iconButton: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fontSizeText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#11181C',
+  },
+  weekCard: {
+    backgroundColor: Brand.primary,
+    borderRadius: 16,
+    padding: 20,
+    gap: 6,
+  },
+  weekLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.75)',
+    letterSpacing: 0.8,
+  },
+  weekAmount: {
+    fontSize: 32,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  weekSub: {
+    fontSize: 13,
+    color: 'rgba(255,255,255,0.75)',
+  },
+  weekDivider: {
+    height: 1,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    marginVertical: 8,
+  },
+  weekRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  weekRowText: {
+    fontSize: 13,
+    color: 'rgba(255,255,255,0.85)',
+  },
+  warningCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FFFBEB',
+    borderWidth: 1,
+    borderColor: '#FCD34D',
+    borderRadius: 14,
+    padding: 16,
+    gap: 12,
+  },
+  warningContent: {
+    flex: 1,
+    gap: 2,
+  },
+  warningTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#D97706',
+  },
+  warningDesc: {
+    fontSize: 12,
+    color: '#D97706',
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  shortcutCard: {
+    width: '47%',
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 16,
+    alignItems: 'flex-start',
+    gap: 14,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  shortcutIconWrap: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  shortcutTextWrap: {
+    gap: 4,
+  },
+  shortcutLabel: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#11181C',
+  },
+  shortcutDesc: {
+    fontSize: 12,
+    color: '#687076',
+    lineHeight: 17,
   },
 });

--- a/workguard-app/app/(tabs)/salary-calendar.tsx
+++ b/workguard-app/app/(tabs)/salary-calendar.tsx
@@ -1,0 +1,39 @@
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { Brand } from '@/constants/theme';
+
+export default function SalaryCalendarScreen() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Ionicons name="calendar-outline" size={48} color="#16A34A" />
+        <Text style={styles.title}>급여 캘린더</Text>
+        <Text style={styles.desc}>준비 중입니다.</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Brand.background,
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#11181C',
+  },
+  desc: {
+    fontSize: 14,
+    color: '#687076',
+  },
+});


### PR DESCRIPTION
## 📜Description
- 메인 홈 화면 및 탭 네비게이션 구현
- 이번 주 급여 카드, 경고 카드, 3개 기능 바로가기 버튼으로 구성

## ✔Checklist
- [x] 정상적으로 빌드가 되는가?
- [x] 로컬에서 정상적으로 실행되는가?

## 🔧Changes
- `app/(tabs)/index.tsx`: 메인 홈 화면 구현
- `app/(tabs)/_layout.tsx`: 탭 4개로 재구성 (홈/계약서/급여 캘린더/챗봇)
- `app/(tabs)/contract.tsx`: 계약서 탭 플레이스홀더
- `app/(tabs)/salary-calendar.tsx`: 급여 캘린더 탭 플레이스홀더
- `app/(tabs)/chatbot.tsx`: 챗봇 탭 플레이스홀더

## 💡Issue
Closed #7 
