### PR TITLE
feat: 계약서 분석 결과 화면 구현 (#19)

### DIFF
--- a/workguard-app/app/(tabs)/_layout.tsx
+++ b/workguard-app/app/(tabs)/_layout.tsx
@@ -28,6 +28,9 @@ export default function TabLayout() {
         name="contract"
         options={{
           title: '계약서',
+          href: '/contract',
+          popToTopOnBlur: true,
+          unmountOnBlur: true,
           tabBarIcon: ({ color }) => <Ionicons name="document-text-outline" size={24} color={color} />,
         }}
       />

--- a/workguard-app/app/(tabs)/contract/_layout.tsx
+++ b/workguard-app/app/(tabs)/contract/_layout.tsx
@@ -6,7 +6,18 @@ export default function ContractStackLayout() {
       screenOptions={{
         headerShown: false,
         contentStyle: { backgroundColor: '#F6F7F9' },
-      }}
-    />
+      }}>
+      <Stack.Screen name="index" />
+      <Stack.Screen name="analyzing" />
+      <Stack.Screen name="result" />
+      <Stack.Screen
+        name="camera"
+        options={{
+          presentation: 'fullScreenModal',
+          animation: 'slide_from_bottom',
+          contentStyle: { backgroundColor: '#000' },
+        }}
+      />
+    </Stack>
   );
 }

--- a/workguard-app/app/(tabs)/contract/analyzing.tsx
+++ b/workguard-app/app/(tabs)/contract/analyzing.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Easing, StyleSheet, Text, View } from 'react-native';
 
@@ -269,6 +270,18 @@ export default function ContractAnalyzingScreen() {
     return () => clearTimeout(progressTimer);
   }, [activeIndex]);
 
+  useEffect(() => {
+    if (activeIndex < BASE_STEPS.length) {
+      return;
+    }
+
+    const navigateTimer = setTimeout(() => {
+      router.replace('/contract/result');
+    }, 700);
+
+    return () => clearTimeout(navigateTimer);
+  }, [activeIndex]);
+
   const steps = useMemo(
     () =>
       BASE_STEPS.map((step, index) => {
@@ -287,13 +300,22 @@ export default function ContractAnalyzingScreen() {
     [activeIndex]
   );
 
+  const isAnalysisComplete = activeIndex >= BASE_STEPS.length;
+
   return (
-    <ContractLayout step={2} rightAction={null}>
+    <ContractLayout
+      step={2}
+      rightAction={null}
+      onBack={() => router.replace('/contract')}>
       <View style={styles.container}>
         <View style={styles.statusSection}>
           <SpinnerIcon />
-          <Text style={styles.statusTitle}>계약서 분석 중이에요</Text>
-          <Text style={styles.statusSub}>잠깐만 기다려 주세요...</Text>
+          <Text style={styles.statusTitle}>
+            {isAnalysisComplete ? '분석 완료했어요!' : '계약서 분석 중이에요'}
+          </Text>
+          <Text style={styles.statusSub}>
+            {isAnalysisComplete ? '결과 화면으로 이동하고 있어요...' : '잠깐만 기다려 주세요...'}
+          </Text>
         </View>
 
         <View style={styles.fileCard}>

--- a/workguard-app/app/(tabs)/contract/camera.tsx
+++ b/workguard-app/app/(tabs)/contract/camera.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../contract-camera';

--- a/workguard-app/app/(tabs)/contract/index.tsx
+++ b/workguard-app/app/(tabs)/contract/index.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
+import { TabActions, useNavigation } from '@react-navigation/native';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { ContractLayout } from '@/components/contract/contract-layout';
@@ -47,8 +48,24 @@ function DocumentMockup() {
 }
 
 export default function ContractUploadScreen() {
+  const navigation = useNavigation();
+  const handleClose = () => {
+    const parent = navigation.getParent();
+
+    if (parent) {
+      parent.dispatch(TabActions.jumpTo('index'));
+      return;
+    }
+
+    router.replace('/');
+  };
+
   return (
-    <ContractLayout step={1} rightAction="close" onBack={() => router.back()}>
+    <ContractLayout
+      step={1}
+      rightAction="home"
+      onBack={handleClose}
+      onRightAction={handleClose}>
       <View style={styles.container}>
 
         {/* 안내 문구 */}
@@ -91,7 +108,7 @@ export default function ContractUploadScreen() {
         <TouchableOpacity
           style={styles.cameraBtn}
           activeOpacity={0.85}
-          onPress={() => router.push('/contract-camera')}>
+          onPress={() => router.push('/contract/camera')}>
           <Ionicons name="camera-outline" size={22} color="#fff" />
           <Text style={styles.cameraBtnText}>카메라로 촬영하기</Text>
         </TouchableOpacity>

--- a/workguard-app/app/(tabs)/contract/result.tsx
+++ b/workguard-app/app/(tabs)/contract/result.tsx
@@ -1,25 +1,456 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { TabActions, useNavigation } from '@react-navigation/native';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { ContractLayout } from '@/components/contract/contract-layout';
 
-export default function ContractResultScreen() {
+type ResultStatus = 'violation' | 'warning' | 'normal';
+type ResultVariant = 'issues' | 'clean';
+
+interface SummaryChipData {
+  label: string;
+  count: number;
+  status: ResultStatus;
+}
+
+interface DetailItem {
+  title: string;
+  law: string;
+  description: string;
+  status: ResultStatus;
+  actionLabel?: string;
+}
+
+interface ResultData {
+  summaryEyebrow: string;
+  summaryTitle: string;
+  summaryBody?: string;
+  summaryEmoji?: string;
+  variant: ResultVariant;
+  chips: SummaryChipData[];
+  items: DetailItem[];
+}
+
+const RESULT_DATA: Record<ResultVariant, ResultData> = {
+  issues: {
+    summaryEyebrow: '분석 완료',
+    summaryTitle: '위반 사항\n3건 발견 됐어요',
+    variant: 'issues',
+    chips: [
+      { label: '위반', count: 1, status: 'violation' },
+      { label: '경고', count: 2, status: 'warning' },
+      { label: '정상', count: 1, status: 'normal' },
+    ],
+    items: [
+      {
+        status: 'violation',
+        law: '근로기준법 제56조',
+        title: '연장근무 수당 미명시',
+        description:
+          '연장근무 시 통상임금의 1.5배 이상을 지급해야 하나, 계약서 내 관련 조항이 없어요.',
+        actionLabel: '신고 방법 보기',
+      },
+      {
+        status: 'warning',
+        law: '근로기준법 제50조',
+        title: '주 52시간 초과 근무 명시',
+        description: '계약서에 주 52시간을 초과한 근무 일정이 기재되어 있어요.',
+        actionLabel: '대응 방법 보기',
+      },
+      {
+        status: 'warning',
+        law: '근로기준법 제55조',
+        title: '주휴일 불명확',
+        description:
+          '주 1회 이상 유급 휴일이 보장되어야 하나, 계약서 내 명시가 불분명해요.',
+        actionLabel: '자세히 보기',
+      },
+      {
+        status: 'normal',
+        law: '최저임금법 제6조',
+        title: '최저임금 기준 충족',
+        description: '계약 시급 ₩ 10,030 - 2026년 최저임금 기준에 충족해요.',
+      },
+    ],
+  },
+  clean: {
+    summaryEyebrow: '분석 완료',
+    summaryTitle: '이상 없어요!',
+    summaryBody: '계약서의 모든 항목이\n한국 노동법 기준에 적합해요.',
+    summaryEmoji: '🎉',
+    variant: 'clean',
+    chips: [{ label: '정상', count: 5, status: 'normal' }],
+    items: [
+      {
+        status: 'normal',
+        law: '근로기준법 제56조',
+        title: '연장 · 야간 · 휴일수당 명시',
+        description: '모든 추가 수당 조항이 계약서에 명확히 기재되어 있어요.',
+      },
+      {
+        status: 'normal',
+        law: '최저임금법 제6조',
+        title: '최저임금 기준 충족',
+        description: '계약 시급 ₩ 10,030 - 2026년 최저임금 기준에 충족해요.',
+      },
+      {
+        status: 'normal',
+        law: '근로기준법 제50조',
+        title: '소정근로시간 적법',
+        description: '주 40시간 이내로 법정 기준에 맞아요.',
+      },
+      {
+        status: 'normal',
+        law: '근로기준법 제50조',
+        title: '주휴일 명시',
+        description: '매주 일요일 유급 휴일로 계약서에 명시되어 있어요.',
+      },
+      {
+        status: 'normal',
+        law: '근로기준법 제17조',
+        title: '계약 필수 항목 모두 포함',
+        description: '임금 · 근로시간 · 업무 내용 등 필수 항목이 모두 기재되어 있어요.',
+      },
+    ],
+  },
+};
+
+function getStatusPalette(status: ResultStatus) {
+  switch (status) {
+    case 'violation':
+      return {
+        line: '#EA2F14',
+        badgeBg: '#FFF0EA',
+        badgeText: '#EA2F14',
+        action: '#EA2F14',
+      };
+    case 'warning':
+      return {
+        line: '#E57B11',
+        badgeBg: '#FFF4E3',
+        badgeText: '#C56A0B',
+        action: '#E57B11',
+      };
+    case 'normal':
+      return {
+        line: '#1F8E39',
+        badgeBg: '#E8F8EA',
+        badgeText: '#1F8E39',
+        action: '#1F8E39',
+      };
+  }
+}
+
+function getStatusLabel(status: ResultStatus) {
+  switch (status) {
+    case 'violation':
+      return '위반';
+    case 'warning':
+      return '경고';
+    case 'normal':
+      return '정상';
+  }
+}
+
+function SummaryChip({ chip }: { chip: SummaryChipData }) {
+  const palette = getStatusPalette(chip.status);
+
   return (
-    <ContractLayout step={3} rightAction="save">
-      <View style={styles.placeholder}>
-        <Text style={styles.text}>분석 결과 화면 (이슈 #15에서 구현)</Text>
+    <View style={[styles.summaryChip, { backgroundColor: palette.badgeBg }]}>
+      <Text style={[styles.summaryChipText, { color: palette.badgeText }]}>
+        {chip.label} {chip.count}건
+      </Text>
+    </View>
+  );
+}
+
+function ResultSummaryCard({ data }: { data: ResultData }) {
+  const isClean = data.variant === 'clean';
+
+  return (
+    <View style={[styles.summaryCard, isClean ? styles.summaryCardClean : styles.summaryCardIssues]}>
+      <Text style={styles.summaryEyebrow}>{data.summaryEyebrow}</Text>
+      <View style={styles.summaryTitleRow}>
+        <Text style={[styles.summaryTitle, styles.summaryTitleIssues]}>{data.summaryTitle}</Text>
+        {data.summaryEmoji ? <Text style={styles.summaryEmoji}>{data.summaryEmoji}</Text> : null}
       </View>
+      {data.summaryBody ? <Text style={styles.summaryBody}>{data.summaryBody}</Text> : null}
+      <View style={styles.summaryChipRow}>
+        {data.chips.map((chip) => (
+          <SummaryChip key={`${chip.status}-${chip.label}`} chip={chip} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function ResultDetailCard({ item }: { item: DetailItem }) {
+  const palette = getStatusPalette(item.status);
+
+  return (
+    <View style={[styles.detailCard, { backgroundColor: palette.line }]}>
+      <View style={styles.detailCardSurface}>
+        <View style={styles.detailCardBody}>
+        <View style={styles.detailHeaderRow}>
+          <View style={[styles.detailStatusBadge, { backgroundColor: palette.badgeBg }]}>
+            <Text style={[styles.detailStatusText, { color: palette.badgeText }]}>
+              {getStatusLabel(item.status)}
+            </Text>
+          </View>
+          <Text style={styles.detailLaw}>{item.law}</Text>
+        </View>
+
+        <Text style={styles.detailTitle}>{item.title}</Text>
+        <Text style={styles.detailDescription}>{item.description}</Text>
+
+        {item.actionLabel ? (
+          <TouchableOpacity activeOpacity={0.8} style={styles.detailAction}>
+            <Text style={[styles.detailActionText, { color: palette.action }]}>{item.actionLabel} →</Text>
+          </TouchableOpacity>
+        ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function FooterCTA() {
+  return (
+    <>
+      <TouchableOpacity style={styles.chatbotCTA} activeOpacity={0.88}>
+        <Ionicons name="chatbubbles-outline" size={28} color="#fff" />
+        <Text style={styles.chatbotCTAText}>챗봇에서 대응 방법 확인하기 →</Text>
+      </TouchableOpacity>
+
+      <View style={styles.disclaimerRow}>
+        <Ionicons name="warning-outline" size={28} color="#8E97A3" />
+        <Text style={styles.disclaimerText}>본 결과는 법률 자문이 아닌 참고용입니다</Text>
+      </View>
+    </>
+  );
+}
+
+export default function ContractResultScreen() {
+  const navigation = useNavigation();
+  const params = useLocalSearchParams<{ variant?: string }>();
+  const variant: ResultVariant = params.variant === 'clean' ? 'clean' : 'issues';
+  const data = RESULT_DATA[variant];
+  const handleClose = () => {
+    const parent = navigation.getParent();
+
+    if (parent) {
+      parent.dispatch(TabActions.jumpTo('index'));
+      return;
+    }
+
+    router.replace('/');
+  };
+
+  return (
+    <ContractLayout
+      step={3}
+      title="결과 확인"
+      rightAction="home"
+      onBack={() => router.replace('/contract')}
+      onRightAction={handleClose}
+      rightContent={
+        variant === 'issues' ? (
+          <TouchableOpacity
+            activeOpacity={0.8}
+            onPress={() => router.replace('/contract/result?variant=clean')}>
+            <Text style={styles.previewActionText}>정상</Text>
+          </TouchableOpacity>
+        ) : null
+      }>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator>
+        <ResultSummaryCard data={data} />
+
+        <View style={styles.detailList}>
+          {data.items.map((item) => (
+            <ResultDetailCard key={`${item.status}-${item.title}`} item={item} />
+          ))}
+        </View>
+
+        <FooterCTA />
+      </ScrollView>
     </ContractLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  placeholder: {
+  scrollView: {
     flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingTop: 14,
+    paddingBottom: 32,
+    gap: 14,
+  },
+  summaryCard: {
+    borderRadius: 24,
+    paddingHorizontal: 22,
+    paddingTop: 18,
+    paddingBottom: 20,
+  },
+  summaryCardIssues: {
+    backgroundColor: '#1B2028',
+  },
+  summaryCardClean: {
+    backgroundColor: '#1F8E39',
+  },
+  summaryEyebrow: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.72)',
+    marginBottom: 10,
+  },
+  summaryTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 6,
+  },
+  summaryTitle: {
+    flexShrink: 1,
+    fontSize: 26,
+    lineHeight: 33,
+    fontWeight: '800',
+    color: '#fff',
+    letterSpacing: -0.8,
+  },
+  summaryTitleIssues: {
+    fontSize: 33,
+    lineHeight: 41,
+    letterSpacing: -1,
+  },
+  summaryEmoji: {
+    fontSize: 26,
+    lineHeight: 33,
+  },
+  summaryBody: {
+    marginTop: 8,
+    fontSize: 15,
+    lineHeight: 22,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.9)',
+  },
+  summaryChipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 18,
+  },
+  summaryChip: {
+    borderRadius: 999,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  summaryChipText: {
+    fontSize: 13,
+    fontWeight: '800',
+  },
+  detailList: {
+    gap: 12,
+  },
+  detailCard: {
+    overflow: 'hidden',
+    borderRadius: 24,
+    shadowColor: '#0F172A',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.04,
+    shadowRadius: 22,
+    elevation: 2,
+  },
+  detailCardSurface: {
+    marginLeft: 4,
+    borderRadius: 20,
+    backgroundColor: '#fff',
+  },
+  detailCardBody: {
+    paddingHorizontal: 18,
+    paddingTop: 18,
+    paddingBottom: 18,
+  },
+  detailHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  detailStatusBadge: {
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+  },
+  detailStatusText: {
+    fontSize: 13,
+    fontWeight: '800',
+  },
+  detailLaw: {
+    flexShrink: 1,
+    textAlign: 'right',
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#9AA3AE',
+  },
+  detailTitle: {
+    marginTop: 14,
+    fontSize: 17,
+    lineHeight: 24,
+    fontWeight: '800',
+    color: '#11181C',
+    letterSpacing: -0.3,
+  },
+  detailDescription: {
+    marginTop: 10,
+    fontSize: 13,
+    lineHeight: 20,
+    fontWeight: '700',
+    color: '#98A2AE',
+  },
+  detailAction: {
+    alignSelf: 'flex-start',
+    marginTop: 14,
+  },
+  detailActionText: {
+    fontSize: 15,
+    fontWeight: '800',
+  },
+  chatbotCTA: {
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    gap: 10,
+    marginTop: 4,
+    borderRadius: 22,
+    backgroundColor: '#3D7EF0',
+    paddingVertical: 18,
+    paddingHorizontal: 18,
   },
-  text: {
-    fontSize: 14,
-    color: '#687076',
+  chatbotCTAText: {
+    fontSize: 15,
+    fontWeight: '800',
+    color: '#fff',
+  },
+  disclaimerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginTop: 8,
+  },
+  disclaimerText: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#8E97A3',
+  },
+  previewActionText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#1F8E39',
   },
 });

--- a/workguard-app/app/(tabs)/index.tsx
+++ b/workguard-app/app/(tabs)/index.tsx
@@ -18,7 +18,7 @@ const SHORTCUTS = [
     icon: 'scan-outline' as const,
     color: Brand.primary,
     bg: '#EBF3FF',
-    route: '/(tabs)/contract',
+    route: '/contract',
   },
   {
     label: '급여 캘린더',

--- a/workguard-app/app/contract-camera.tsx
+++ b/workguard-app/app/contract-camera.tsx
@@ -121,7 +121,7 @@ export default function ContractCameraScreen() {
         <TouchableOpacity
           style={styles.ctaBtn}
           activeOpacity={0.85}
-          onPress={() => router.replace('/(tabs)/contract/analyzing')}>
+          onPress={() => router.replace('/contract/analyzing')}>
           <Text style={styles.ctaBtnText}>촬영 완료 · 분석 시작하기 →</Text>
         </TouchableOpacity>
 

--- a/workguard-app/components/contract/contract-layout.tsx
+++ b/workguard-app/components/contract/contract-layout.tsx
@@ -11,14 +11,15 @@ interface ContractLayoutProps {
   title?: string;
   children: ReactNode;
   onBack?: () => void;
-  rightAction?: 'close' | 'save' | null;
+  rightAction?: 'close' | 'save' | 'home' | null;
   onRightAction?: () => void;
+  rightContent?: ReactNode;
 }
 
 const DEFAULT_TITLES: Record<1 | 2 | 3, string> = {
   1: '계약서 분석',
   2: '분석 중',
-  3: '분석 중',
+  3: '결과 확인',
 };
 
 export function ContractLayout({
@@ -28,6 +29,7 @@ export function ContractLayout({
   onBack,
   rightAction = 'close',
   onRightAction,
+  rightContent,
 }: ContractLayoutProps) {
   const insets = useSafeAreaInsets();
   const headerTitle = title ?? DEFAULT_TITLES[step];
@@ -42,13 +44,20 @@ export function ContractLayout({
             </View>
             <Text style={styles.headerTitle}>{headerTitle}</Text>
           </TouchableOpacity>
-          {rightAction && (
-            <TouchableOpacity onPress={onRightAction}>
-              <Text style={styles.rightActionText}>
-                {rightAction === 'close' ? '닫기' : '저장'}
-              </Text>
-            </TouchableOpacity>
-          )}
+          <View style={styles.rightActions}>
+            {rightContent}
+            {rightAction && (
+              <TouchableOpacity onPress={onRightAction}>
+                {rightAction === 'home' ? (
+                  <Ionicons name="home-outline" size={22} color="#687076" />
+                ) : (
+                  <Text style={styles.rightActionText}>
+                    {rightAction === 'close' ? '닫기' : '저장'}
+                  </Text>
+                )}
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
 
         <StepIndicator currentStep={step} />
@@ -103,6 +112,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#687076',
     paddingHorizontal: 4,
+  },
+  rightActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
   },
   content: {
     flex: 1,

--- a/workguard-app/components/contract/step-indicator.tsx
+++ b/workguard-app/components/contract/step-indicator.tsx
@@ -54,7 +54,7 @@ export function StepIndicator({ currentStep }: StepIndicatorProps) {
                   status === 'completed' && styles.circleCompleted,
                 ]}>
                 {status === 'completed' ? (
-                  <Ionicons name="checkmark" size={14} color="#fff" />
+                  <Ionicons name="checkmark" size={14} color="#2F9448" />
                 ) : (
                   <Text
                     style={[


### PR DESCRIPTION
## 📜Description
피그마 디자인 기반 계약서 분석 결과 화면을 구현했습니다.
위반 사항이 있는 결과와 전부 정상인 결과를 모두 표시할 수 있도록 결과 화면 variant를 구성했습니다.

## ✔Checklist
- [ ] 정상적으로 빌드가 되는가?
- [ ] 로컬에서 정상적으로 실행되는가?
- [ ] 분석 진행 화면에서 결과 화면으로 이동 가능한가?
- [ ] 위반 결과 화면이 정상적으로 표시되는가?
- [ ] 정상 결과 화면이 정상적으로 표시되는가?
- [ ] 결과 카드가 여러 개일 때 스크롤 가능한가?
- [ ] 피그마 디자인과 주요 레이아웃이 일치하는가?

## 🔧Changes
- 계약서 분석 결과 화면 UI 구현
- 위반 결과/정상 결과 variant 구현
- 결과 요약 카드 구현
- 위반/경고/정상 결과 카드 구현
- 결과 리스트 스크롤 처리

## 💡Issue
Closed #19