### PR TITLE
feat: WorkLog DB 모델 추가

### DIFF
--- a/workguard-server/app/db/models.py
+++ b/workguard-server/app/db/models.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+from datetime import date as DateType
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 from uuid import uuid4
 
 from sqlmodel import Field, SQLModel
@@ -31,3 +32,18 @@ class ContractAnalysis(SQLModel, table=True):
     @property
     def items(self) -> list[dict[str, Any]]:
         return json.loads(self.items_json)
+
+class WorkLog(SQLModel, table=True):
+    id: str = Field(default_factory=lambda: uuid4().hex, primary_key=True)
+    log_date: DateType = Field(index=True)
+    
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    fee: Optional[int] = None
+    overtime_hours: float = 0.0
+    is_night_shift: bool = False
+    is_holiday_work: bool = False
+    
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    


### PR DESCRIPTION
## 개요
급여 캘린더 백엔드 구현을 위한 WorkLog DB 모델을 추가합니다.

## 변경 사항
- `app/db/models.py`에 `WorkLog` 클래스 추가

## WorkLog 필드
| 필드 | 설명 |
|------|------|
| `log_date` | 근무 날짜 |
| `start_time` | 출근 시간 |
| `end_time` | 퇴근 시간 |
| `fee` | 시급 (원) |
| `overtime_hours` | 초과근무 시간 |
| `is_night_shift` | 야간 근무 여부 |
| `is_holiday_work` | 휴일 근무 여부 |

## 관련 이슈
Closes #45
