### PR TITLE
feat: 급여 캘린더 API 엔드포인트 및 라우터 등록

### DIFF
--- a/workguard-server/app/routers/work_logs.py
+++ b/workguard-server/app/routers/work_logs.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from app.db.database import get_session
+from app.db.models import WorkLog
+
+router = APIRouter(prefix='/work-logs', tags=['work_logs'])
+
+class WorkLogRequest(BaseModel):
+    log_date: date
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    fee: Optional[int] = None
+    overtime_hours: float = 0.0
+    is_night_shift: bool = False
+    is_holiday_work: bool = False
+    
+class WorkLogResponse(BaseModel):
+    id: str
+    log_date: date
+    start_time: Optional[str]
+    end_time: Optional[str]
+    fee: Optional[int]
+    overtime_hours: float
+    is_night_shift: bool
+    is_holiday_work: bool
+    
+@router.get("/{year}/{month}", response_model=list[WorkLogResponse])
+def get_monthly_logs(year: int, month: int, session: Session = Depends(get_session)):
+    logs = session.exec(select(WorkLog)).all()
+    return [l for l in logs if l.log_date.year == year and l.log_date.month == month]
+
+@router.get("/{year}/{month}/{day}", response_model=WorkLogResponse)
+def get_daily_log(year: int, month: int, day: int, session: Session = Depends(get_session)):
+    target = date(year, month, day)
+    log = session.exec(select(WorkLog).where(WorkLog.log_date == target)).first()
+    if not log:
+        raise HTTPException(status_code=404, detail="Work log not found")
+    return log
+
+@router.post("", response_model=WorkLogResponse)
+def create_log(body: WorkLogRequest, session: Session = Depends(get_session)):
+    log = WorkLog(**body.model_dump())
+    session.add(log)
+    session.commit()
+    session.refresh(log)
+    return log
+
+@router.put("/{log_id}", response_model=WorkLogResponse)
+def update_log(log_id: str, body: WorkLogRequest, session: Session = Depends(get_session)):
+    log = session.get(WorkLog, log_id)
+    if not log:
+        raise HTTPException(status_code=404, detail="Work log not found")
+    for key, value in body.model_dump().items():
+        setattr(log, key, value)
+    session.add(log)
+    session.commit()
+    session.refresh(log)
+    return log

--- a/workguard-server/main.py
+++ b/workguard-server/main.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.db.database import init_db
 from app.routers.contracts import router as contracts_router
+from app.routers.work_logs import router as work_logs_router
 from app.services.retriever import ensure_collection
 
 logging.basicConfig(
@@ -36,6 +37,7 @@ app.add_middleware(
 )
 
 app.include_router(contracts_router)
+app.include_router(work_logs_router)
 
 
 @app.get("/health")


### PR DESCRIPTION
## 개요
급여 캘린더의 근무 기록 CRUD API를 구현하고 메인 앱에 등록합니다.

## 변경 사항
- `app/routers/work_logs.py` 생성
- `main.py`에 work_logs 라우터 등록

## 엔드포인트
| 메서드 | 경로 | 설명 |
|--------|------|------|
| GET | /work-logs/{year}/{month} | 월별 기록 조회 |
| GET | /work-logs/{year}/{month}/{day} | 특정 날짜 기록 조회 |
| POST | /work-logs | 새 기록 저장 |
| PUT | /work-logs/{log_id} | 기존 기록 수정 |

## 관련 이슈
Closes #47
