### PR TITLE
feat: 계약서 등록 카메라 촬영 및 갤러리 다중 선택 구현 #52

### DIFF
--- a/workguard-app/app.json
+++ b/workguard-app/app.json
@@ -38,6 +38,18 @@
             "backgroundColor": "#3182F6"
           }
         }
+      ],
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "계약서 촬영을 위해 카메라 접근을 허용해 주세요."
+        }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "계약서 사진 선택을 위해 사진 보관함 접근을 허용해 주세요."
+        }
       ]
     ],
     "experiments": {

--- a/workguard-app/app/(tabs)/contract/index.tsx
+++ b/workguard-app/app/(tabs)/contract/index.tsx
@@ -1,7 +1,8 @@
 import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
 import { router } from 'expo-router';
 import { TabActions, useNavigation } from '@react-navigation/native';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { ContractLayout } from '@/components/contract/contract-layout';
 
@@ -49,6 +50,18 @@ function DocumentMockup() {
 
 export default function ContractUploadScreen() {
   const navigation = useNavigation();
+  async function pickFromGallery() {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsMultipleSelection: true,
+      selectionLimit: 0,
+      quality: 0.8,
+    });
+    if (!result.canceled && result.assets.length > 0) {
+      router.push('/contract/analyzing');
+    }
+  }
+
   const handleClose = () => {
     const parent = navigation.getParent();
 
@@ -122,11 +135,14 @@ export default function ContractUploadScreen() {
 
         {/* 보조 버튼 */}
         <View style={styles.secondaryRow}>
-          <TouchableOpacity style={styles.secondaryBtn} activeOpacity={0.8}>
+          <TouchableOpacity style={styles.secondaryBtn} activeOpacity={0.8} onPress={pickFromGallery}>
             <Ionicons name="image-outline" size={24} color="#11181C" />
             <Text style={styles.secondaryBtnText}>사진 보관함</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.secondaryBtn} activeOpacity={0.8}>
+          <TouchableOpacity
+            style={styles.secondaryBtn}
+            activeOpacity={0.8}
+            onPress={() => Alert.alert('준비 중이에요', '파일 선택 기능은 곧 추가될 예정이에요.')}>
             <Ionicons name="document-outline" size={24} color="#11181C" />
             <Text style={styles.secondaryBtnText}>파일 앱에서 선택</Text>
           </TouchableOpacity>

--- a/workguard-app/app/contract-camera.tsx
+++ b/workguard-app/app/contract-camera.tsx
@@ -1,19 +1,91 @@
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import * as ImagePicker from 'expo-image-picker';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
-import { useState } from 'react';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useRef, useState } from 'react';
+import {
+  Alert,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const CAPTURED_PAGES = [1, 2];
 const CORNER = 44;
 const CORNER_W = 4;
 const CORNER_COLOR = '#3182F6';
-const DOC_INSET = 20;
 
 export default function ContractCameraScreen() {
   const insets = useSafeAreaInsets();
-  const [totalPages, setTotalPages] = useState(5);
-  const [currentPage, setCurrentPage] = useState(3);
+  const [permission, requestPermission] = useCameraPermissions();
+  const [images, setImages] = useState<string[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const cameraRef = useRef<CameraView>(null);
+
+  async function takePicture() {
+    if (!cameraRef.current) return;
+    try {
+      const photo = await cameraRef.current.takePictureAsync({ quality: 0.8 });
+      if (photo?.uri) {
+        setImages(prev => [...prev, photo.uri]);
+        setSelectedIndex(null);
+      }
+    } catch {
+      Alert.alert('오류', '사진 촬영에 실패했어요. 다시 시도해 주세요.');
+    }
+  }
+
+  async function pickFromGallery() {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsMultipleSelection: true,
+      selectionLimit: 0,
+      quality: 0.8,
+    });
+    if (!result.canceled && result.assets.length > 0) {
+      setImages(prev => [...prev, ...result.assets.map(a => a.uri)]);
+      setSelectedIndex(null);
+    }
+  }
+
+  function deleteImage(index: number) {
+    Alert.alert('페이지 삭제', `${index + 1}페이지를 삭제할까요?`, [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '삭제',
+        style: 'destructive',
+        onPress: () => {
+          setImages(prev => prev.filter((_, i) => i !== index));
+          setSelectedIndex(null);
+        },
+      },
+    ]);
+  }
+
+  if (!permission) return <View style={{ flex: 1, backgroundColor: '#000' }} />;
+
+  if (!permission.granted) {
+    return (
+      <View style={[styles.container, { paddingTop: insets.top + 8, paddingBottom: insets.bottom + 8 }]}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.closeBtn}>
+          <Ionicons name="close" size={26} color="#fff" />
+        </TouchableOpacity>
+        <View style={styles.permContent}>
+          <Ionicons name="camera-outline" size={56} color="#9BA1A6" />
+          <Text style={styles.permTitle}>카메라 권한이 필요해요</Text>
+          <Text style={styles.permSub}>계약서 촬영을 위해 카메라 접근을 허용해 주세요.</Text>
+          <TouchableOpacity style={styles.permBtn} onPress={requestPermission}>
+            <Text style={styles.permBtnText}>권한 허용하기</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
+
+  const previewUri = selectedIndex !== null ? images[selectedIndex] : null;
 
   return (
     <View style={[styles.container, { paddingTop: insets.top + 8, paddingBottom: insets.bottom + 8 }]}>
@@ -23,27 +95,38 @@ export default function ContractCameraScreen() {
         <Ionicons name="close" size={26} color="#fff" />
       </TouchableOpacity>
 
-      {/* 뷰파인더 — flex:1 로 남은 세로 공간 전부 */}
+      {/* 뷰파인더 */}
       <View style={styles.viewfinder}>
-        <View style={styles.docPreview}>
-          <View style={styles.docLines}>
-            {[88, 72, 80, 65, 85, 70, 78, 60, 74].map((w, i) => (
-              <View key={i} style={[styles.docLine, { width: `${w}%` as any }]} />
-            ))}
-          </View>
-          <View style={styles.guidePill}>
-            <Text style={styles.guidePillText}>계약서를 프레임 안에 맞춰주세요</Text>
-          </View>
-        </View>
+        <CameraView ref={cameraRef} style={StyleSheet.absoluteFill} facing="back" />
 
-        {/* 코너 브라켓 — docPreview 위에 렌더링 */}
+        {/* 촬영 이미지 미리보기 오버레이 */}
+        {previewUri && (
+          <View style={[StyleSheet.absoluteFill, styles.previewOverlay]}>
+            <Image source={{ uri: previewUri }} style={StyleSheet.absoluteFill} resizeMode="contain" />
+            <TouchableOpacity style={styles.previewBackBtn} onPress={() => setSelectedIndex(null)}>
+              <Ionicons name="camera-outline" size={16} color="#fff" />
+              <Text style={styles.previewBackText}>카메라로 돌아가기</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {/* 촬영 가이드 */}
+        {!previewUri && (
+          <View style={styles.guideWrap}>
+            <View style={styles.guidePill}>
+              <Text style={styles.guidePillText}>계약서를 프레임 안에 맞춰주세요</Text>
+            </View>
+          </View>
+        )}
+
+        {/* 코너 브라켓 */}
         <View style={[styles.corner, styles.cTL]} />
         <View style={[styles.corner, styles.cTR]} />
         <View style={[styles.corner, styles.cBL]} />
         <View style={[styles.corner, styles.cBR]} />
       </View>
 
-      {/* 하단 컨트롤 — 단일 View로 묶어서 flex 영향 차단 */}
+      {/* 하단 컨트롤 */}
       <View style={styles.bottomControls}>
 
         {/* 페이지 썸네일 */}
@@ -51,52 +134,56 @@ export default function ContractCameraScreen() {
           horizontal
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={styles.thumbRow}>
-          {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => {
-            const captured = CAPTURED_PAGES.includes(page);
-            const selected = page === currentPage;
+          {images.map((uri, i) => {
+            const selected = selectedIndex === i;
             return (
               <TouchableOpacity
-                key={page}
+                key={`${uri}-${i}`}
                 style={[styles.thumb, selected && styles.thumbSelected]}
-                onPress={() => setCurrentPage(page)}>
-                {captured && (
+                onPress={() => setSelectedIndex(selected ? null : i)}
+                onLongPress={() => deleteImage(i)}>
+                <Image source={{ uri }} style={styles.thumbImage} />
+                {selected && (
                   <View style={styles.thumbCheck}>
-                    <Ionicons name="checkmark-circle" size={14} color="#16A34A" />
+                    <Ionicons name="checkmark-circle" size={14} color={CORNER_COLOR} />
                   </View>
                 )}
-                <View style={styles.thumbDoc}>
-                  {[70, 90, 55, 75].map((w, i) => (
-                    <View key={i} style={[styles.thumbLine, { width: `${w}%` as any }]} />
-                  ))}
-                </View>
                 <Text style={[styles.thumbLabel, selected && styles.thumbLabelSelected]}>
-                  {page}p
+                  {i + 1}p
                 </Text>
               </TouchableOpacity>
             );
           })}
-          <TouchableOpacity
-            style={styles.thumbAdd}
-            onPress={() => {
-              const next = totalPages + 1;
-              setTotalPages(next);
-              setCurrentPage(next);
-            }}>
+          <TouchableOpacity style={styles.thumbAdd} onPress={() => setSelectedIndex(null)}>
             <Ionicons name="add" size={20} color="#9BA1A6" />
           </TouchableOpacity>
         </ScrollView>
 
         {/* 이전 / 페이지 수 / 다음 */}
         <View style={styles.pageNav}>
-          <TouchableOpacity style={styles.pageNavBtn} onPress={() => setCurrentPage(p => Math.max(1, p - 1))}>
+          <TouchableOpacity
+            style={styles.pageNavBtn}
+            disabled={selectedIndex === null || selectedIndex === 0}
+            onPress={() => selectedIndex !== null && setSelectedIndex(selectedIndex - 1)}>
             <Ionicons name="chevron-back" size={14} color="#fff" />
             <Text style={styles.pageNavText}>이전</Text>
           </TouchableOpacity>
           <Text>
-            <Text style={styles.pageCountNum}>{currentPage}</Text>
-            <Text style={styles.pageCountTotal}> / {totalPages} 페이지</Text>
+            {selectedIndex !== null ? (
+              <>
+                <Text style={styles.pageCountNum}>{selectedIndex + 1}</Text>
+                <Text style={styles.pageCountTotal}> / {images.length} 페이지</Text>
+              </>
+            ) : (
+              <Text style={styles.pageCountTotal}>
+                {images.length > 0 ? `${images.length}장 · 새 페이지 촬영` : '촬영을 시작해 주세요'}
+              </Text>
+            )}
           </Text>
-          <TouchableOpacity style={styles.pageNavBtn} onPress={() => setCurrentPage(p => Math.min(totalPages, p + 1))}>
+          <TouchableOpacity
+            style={styles.pageNavBtn}
+            disabled={selectedIndex === null || selectedIndex >= images.length - 1}
+            onPress={() => selectedIndex !== null && setSelectedIndex(selectedIndex + 1)}>
             <Text style={styles.pageNavText}>다음</Text>
             <Ionicons name="chevron-forward" size={14} color="#fff" />
           </TouchableOpacity>
@@ -104,14 +191,19 @@ export default function ContractCameraScreen() {
 
         {/* 갤러리 / 촬영 / 파일 */}
         <View style={styles.actionRow}>
-          <TouchableOpacity style={styles.actionBtn}>
+          <TouchableOpacity style={styles.actionBtn} onPress={pickFromGallery}>
             <Ionicons name="image-outline" size={26} color="#fff" />
             <Text style={styles.actionLabel}>갤러리</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.captureBtn}>
-            <View style={styles.captureBtnInner} />
+          <TouchableOpacity
+            style={[styles.captureBtn, !!previewUri && styles.captureBtnDisabled]}
+            onPress={previewUri ? undefined : takePicture}
+            disabled={!!previewUri}>
+            <View style={[styles.captureBtnInner, !!previewUri && styles.captureBtnInnerDisabled]} />
           </TouchableOpacity>
-          <TouchableOpacity style={styles.actionBtn}>
+          <TouchableOpacity
+            style={styles.actionBtn}
+            onPress={() => Alert.alert('준비 중이에요', '파일 선택 기능은 곧 추가될 예정이에요.')}>
             <Ionicons name="document-outline" size={26} color="#fff" />
             <Text style={styles.actionLabel}>파일</Text>
           </TouchableOpacity>
@@ -119,10 +211,15 @@ export default function ContractCameraScreen() {
 
         {/* CTA */}
         <TouchableOpacity
-          style={styles.ctaBtn}
+          style={[styles.ctaBtn, images.length === 0 && styles.ctaBtnDisabled]}
           activeOpacity={0.85}
+          disabled={images.length === 0}
           onPress={() => router.replace('/contract/analyzing')}>
-          <Text style={styles.ctaBtnText}>촬영 완료 · 분석 시작하기 →</Text>
+          <Text style={styles.ctaBtnText}>
+            {images.length === 0
+              ? '사진을 추가해 주세요'
+              : `${images.length}장 완료 · 분석 시작하기 →`}
+          </Text>
         </TouchableOpacity>
 
       </View>
@@ -144,44 +241,92 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
 
+  // 권한 요청
+  permContent: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    paddingHorizontal: 24,
+  },
+  permTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#fff',
+    marginTop: 8,
+  },
+  permSub: {
+    fontSize: 14,
+    color: '#9BA1A6',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  permBtn: {
+    marginTop: 8,
+    backgroundColor: '#3182F6',
+    borderRadius: 14,
+    paddingHorizontal: 28,
+    paddingVertical: 14,
+  },
+  permBtnText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+
+  // 뷰파인더
   viewfinder: {
     flex: 1,
     position: 'relative',
     marginBottom: 12,
+    overflow: 'hidden',
+    borderRadius: 16,
   },
 
-  corner: { position: 'absolute', width: CORNER, height: CORNER, zIndex: 2 },
-  cTL: { top: 0, left: 0, borderTopWidth: CORNER_W, borderLeftWidth: CORNER_W, borderColor: CORNER_COLOR, borderTopLeftRadius: 20 },
-  cTR: { top: 0, right: 0, borderTopWidth: CORNER_W, borderRightWidth: CORNER_W, borderColor: CORNER_COLOR, borderTopRightRadius: 20 },
-  cBL: { bottom: 0, left: 0, borderBottomWidth: CORNER_W, borderLeftWidth: CORNER_W, borderColor: CORNER_COLOR, borderBottomLeftRadius: 20 },
-  cBR: { bottom: 0, right: 0, borderBottomWidth: CORNER_W, borderRightWidth: CORNER_W, borderColor: CORNER_COLOR, borderBottomRightRadius: 20 },
-
-  docPreview: {
+  previewOverlay: {
+    backgroundColor: '#000',
+    borderRadius: 16,
+  },
+  previewBackBtn: {
     position: 'absolute',
-    top: DOC_INSET,
-    left: DOC_INSET,
-    right: DOC_INSET,
-    bottom: DOC_INSET,
-    backgroundColor: '#2C2C2E',
-    borderRadius: 14,
-    padding: 20,
-    justifyContent: 'space-between',
-  },
-  docLines: { gap: 9 },
-  docLine: { height: 8, backgroundColor: '#48484A', borderRadius: 4 },
-  guidePill: {
+    bottom: 16,
     alignSelf: 'center',
-    backgroundColor: 'rgba(0,0,0,0.65)',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    borderRadius: 20,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  previewBackText: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+
+  guideWrap: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    paddingBottom: 20,
+  },
+  guidePill: {
+    backgroundColor: 'rgba(0,0,0,0.55)',
     borderRadius: 20,
     paddingHorizontal: 16,
     paddingVertical: 8,
   },
   guidePillText: { color: '#fff', fontSize: 14, fontWeight: '500' },
 
-  // 하단 전체 묶음 — flex 없음
-  bottomControls: {
-    gap: 12,
-  },
+  corner: { position: 'absolute', width: CORNER, height: CORNER, zIndex: 2 },
+  cTL: { top: 0, left: 0, borderTopWidth: CORNER_W, borderLeftWidth: CORNER_W, borderColor: CORNER_COLOR, borderTopLeftRadius: 16 },
+  cTR: { top: 0, right: 0, borderTopWidth: CORNER_W, borderRightWidth: CORNER_W, borderColor: CORNER_COLOR, borderTopRightRadius: 16 },
+  cBL: { bottom: 0, left: 0, borderBottomWidth: CORNER_W, borderLeftWidth: CORNER_W, borderColor: CORNER_COLOR, borderBottomLeftRadius: 16 },
+  cBR: { bottom: 0, right: 0, borderBottomWidth: CORNER_W, borderRightWidth: CORNER_W, borderColor: CORNER_COLOR, borderBottomRightRadius: 16 },
+
+  // 하단
+  bottomControls: { gap: 12 },
 
   thumbRow: { gap: 8, alignItems: 'center' },
   thumb: {
@@ -191,16 +336,26 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     borderWidth: 1.5,
     borderColor: '#48484A',
+    overflow: 'hidden',
     alignItems: 'center',
-    justifyContent: 'center',
-    padding: 6,
-    gap: 4,
+    justifyContent: 'flex-end',
+    padding: 0,
   },
   thumbSelected: { borderColor: CORNER_COLOR },
+  thumbImage: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 6,
+  },
   thumbCheck: { position: 'absolute', top: 3, right: 3 },
-  thumbDoc: { width: '100%', gap: 3 },
-  thumbLine: { height: 3, backgroundColor: '#636366', borderRadius: 2 },
-  thumbLabel: { fontSize: 10, color: '#9BA1A6', fontWeight: '600' },
+  thumbLabel: {
+    fontSize: 10,
+    color: '#fff',
+    fontWeight: '700',
+    marginBottom: 4,
+    textShadowColor: 'rgba(0,0,0,0.8)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+  },
   thumbLabelSelected: { color: CORNER_COLOR },
   thumbAdd: {
     width: 52,
@@ -248,6 +403,7 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   actionLabel: { color: '#9BA1A6', fontSize: 11 },
+
   captureBtn: {
     width: 72,
     height: 72,
@@ -257,12 +413,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  captureBtnDisabled: { borderColor: '#3A3A3C', opacity: 0.4 },
   captureBtnInner: {
     width: 56,
     height: 56,
     borderRadius: 28,
     backgroundColor: '#FF3B30',
   },
+  captureBtnInnerDisabled: { backgroundColor: '#636366' },
 
   ctaBtn: {
     backgroundColor: CORNER_COLOR,
@@ -270,5 +428,6 @@ const styles = StyleSheet.create({
     paddingVertical: 18,
     alignItems: 'center',
   },
+  ctaBtnDisabled: { backgroundColor: '#2C2C2E' },
   ctaBtnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
 });

--- a/workguard-app/package.json
+++ b/workguard-app/package.json
@@ -16,10 +16,12 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "expo": "~54.0.33",
+    "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-image-picker": "~17.0.11",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-splash-screen": "~31.0.13",
@@ -31,11 +33,11 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",


### PR DESCRIPTION
## 🔨 작업 내용

계약서 등록 화면에 실제 카메라 촬영 및 갤러리 다중 선택 기능 구현

---

## 🐛 현재 문제

`contract-camera.tsx`가 UI 목업 상태로, 실제 카메라 촬영 및 갤러리 선택 기능이 동작하지 않음

- 카메라 뷰파인더가 하드코딩된 더미 UI
- 갤러리 / 파일 버튼에 `onPress` 없음
- `expo-camera`, `expo-image-picker` 패키지 미설치
- 계약서가 여러 페이지일 경우 다중 선택 불가

---

## 📋 구현 사항

**패키지 추가**
- `expo-camera` — 카메라 촬영
- `expo-image-picker` — 갤러리 다중 선택

**`app/contract-camera.tsx`**
- `CameraView`로 실시간 카메라 뷰파인더 교체
- 카메라 권한 요청 UI 추가 (미허용 시 안내 화면)
- 촬영 버튼으로 사진 찍기 → 하단 썸네일에 실제 이미지 추가
- 갤러리 버튼 → `allowsMultipleSelection`, `selectionLimit: 0` 으로 여러 장 한 번에 선택
- 썸네일 탭 → 해당 이미지 미리보기 오버레이
- 썸네일 길게 누르기 → 페이지 삭제
- 사진 없으면 CTA 비활성화, 추가되면 `N장 완료 · 분석 시작하기 →` 표시

**`app/(tabs)/contract/index.tsx`**
- "사진 보관함" 버튼에 갤러리 피커 연결 (다중 선택 후 바로 분석 화면으로 이동)
- "파일 앱에서 선택" 버튼 준비 중 알림 추가

**`app.json`**
- `expo-camera`, `expo-image-picker` 플러그인 및 권한 문구 추가

---

## ⚠️ 작업 방식 참고

로컬 작업분이 dev에 반영되지 않은 상태여서 아래 순서로 진행

1. 기존 작업 파일 별도 복사 보관
2. `dev` 최신 pull
3. 복사해둔 작업 파일 덮어씌우기
4. push → PR → merge

---

💡 Issue
Closed #52