### PR TITLE
fix: 계약서 분석 플로우 전체 연결 및 결과 화면 표시 수정 (#57)

### DIFF
--- a/workguard-app/app/(tabs)/contract/analyzing.tsx
+++ b/workguard-app/app/(tabs)/contract/analyzing.tsx
@@ -1,7 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Animated, Easing, StyleSheet, Text, View } from 'react-native';
+import { Alert, Animated, Easing, StyleSheet, Text, View } from 'react-native';
+import { contractStore } from '@/store/contractStore';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
 
 import { ContractLayout } from '@/components/contract/contract-layout';
 
@@ -255,32 +258,71 @@ function StepRow({ step, index }: { step: { label: string; sub: string; status: 
   );
 }
 
+async function analyzeImages(images: string[]): Promise<void> {
+  for (const uri of images) {
+    const formData = new FormData();
+    const filename = uri.split('/').pop() ?? 'contract.jpg';
+    formData.append('file', { uri, name: filename, type: 'image/jpeg' } as any);
+
+    const response = await fetch(`${API_BASE_URL}/contracts/analyze`, {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`서버 오류 (${response.status}): ${err}`);
+    }
+
+    const result = await response.json();
+    console.log('[analyzing] API 응답 수신, is_clean:', result?.is_clean, '| items:', result?.items?.length);
+    contractStore.setResult(result);
+    console.log('[analyzing] contractStore.setResult 완료, getResult():', contractStore.getResult()?.is_clean);
+    return; // 첫 번째 이미지 결과만 사용 (추후 다중 페이지 지원 확장)
+  }
+}
+
 export default function ContractAnalyzingScreen() {
   const [activeIndex, setActiveIndex] = useState(0);
+  const [apiDone, setApiDone] = useState(false);
+  const pageCount = contractStore.getImages().length;
 
+  // API 호출 - 완료되면 apiDone=true, 절대 타이머로 네비게이션 안 함
   useEffect(() => {
-    if (activeIndex >= BASE_STEPS.length) {
-      return;
+    const images = contractStore.getImages();
+    console.log('[analyzing] 이미지 개수:', images.length, '| API_URL:', API_BASE_URL);
+
+    if (images.length === 0) {
+      console.warn('[analyzing] 이미지가 없어요! contractStore.getImages() = []');
     }
 
-    const progressTimer = setTimeout(() => {
-      setActiveIndex((prev) => prev + 1);
-    }, 700);
+    analyzeImages(images)
+      .then(() => {
+        console.log('[analyzing] analyzeImages 완료 → setApiDone(true)');
+        setApiDone(true);
+      })
+      .catch((err) => {
+        console.error('[analyzing] 오류:', err.message);
+        Alert.alert('분석 실패', err.message ?? '서버에 연결할 수 없어요.', [
+          { text: '돌아가기', onPress: () => router.back() },
+        ]);
+      });
+  }, []);
 
-    return () => clearTimeout(progressTimer);
-  }, [activeIndex]);
-
+  // 애니메이션: 3번째 스텝까지만 자동 진행 (마지막은 API 완료 시)
   useEffect(() => {
-    if (activeIndex < BASE_STEPS.length) {
-      return;
-    }
-
-    const navigateTimer = setTimeout(() => {
-      router.replace('/contract/result');
-    }, 700);
-
-    return () => clearTimeout(navigateTimer);
+    if (activeIndex >= BASE_STEPS.length - 1) return;
+    const t = setTimeout(() => setActiveIndex((p) => p + 1), 2000);
+    return () => clearTimeout(t);
   }, [activeIndex]);
+
+  // API 완료되면 마지막 스텝 표시 후 result로 이동
+  useEffect(() => {
+    if (!apiDone) return;
+    setActiveIndex(BASE_STEPS.length);
+    const t = setTimeout(() => router.replace('/contract/result'), 800);
+    return () => clearTimeout(t);
+  }, [apiDone]);
 
   const steps = useMemo(
     () =>
@@ -327,7 +369,7 @@ export default function ContractAnalyzingScreen() {
               근로계약서.jpg
             </Text>
             <View style={styles.fileMetaRow}>
-              <Text style={styles.fileMeta}>7페이지</Text>
+              <Text style={styles.fileMeta}>{pageCount}페이지</Text>
             </View>
           </View>
           <View style={styles.fileUploadBadge}>

--- a/workguard-app/app/(tabs)/contract/index.tsx
+++ b/workguard-app/app/(tabs)/contract/index.tsx
@@ -5,6 +5,7 @@ import { TabActions, useNavigation } from '@react-navigation/native';
 import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { ContractLayout } from '@/components/contract/contract-layout';
+import { contractStore } from '@/store/contractStore';
 
 const BAD_EXAMPLES = [
   {
@@ -58,6 +59,7 @@ export default function ContractUploadScreen() {
       quality: 0.8,
     });
     if (!result.canceled && result.assets.length > 0) {
+      contractStore.setImages(result.assets.map(a => a.uri));
       router.push('/contract/analyzing');
     }
   }

--- a/workguard-app/app/(tabs)/contract/result.tsx
+++ b/workguard-app/app/(tabs)/contract/result.tsx
@@ -1,251 +1,107 @@
 import { Ionicons } from '@expo/vector-icons';
-import { router, useLocalSearchParams } from 'expo-router';
+import { router } from 'expo-router';
 import { TabActions, useNavigation } from '@react-navigation/native';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { ContractLayout } from '@/components/contract/contract-layout';
+import { contractStore, type AnalysisItem } from '@/store/contractStore';
 
-type ResultStatus = 'violation' | 'warning' | 'normal';
-type ResultVariant = 'issues' | 'clean';
-
-interface SummaryChipData {
-  label: string;
-  count: number;
-  status: ResultStatus;
-}
-
-interface DetailItem {
-  title: string;
-  law: string;
-  description: string;
-  status: ResultStatus;
-  actionLabel?: string;
-}
-
-interface ResultData {
-  summaryEyebrow: string;
-  summaryTitle: string;
-  summaryBody?: string;
-  summaryEmoji?: string;
-  variant: ResultVariant;
-  chips: SummaryChipData[];
-  items: DetailItem[];
-}
-
-const RESULT_DATA: Record<ResultVariant, ResultData> = {
-  issues: {
-    summaryEyebrow: '분석 완료',
-    summaryTitle: '위반 사항\n3건 발견 됐어요',
-    variant: 'issues',
-    chips: [
-      { label: '위반', count: 1, status: 'violation' },
-      { label: '경고', count: 2, status: 'warning' },
-      { label: '정상', count: 1, status: 'normal' },
-    ],
-    items: [
-      {
-        status: 'violation',
-        law: '근로기준법 제56조',
-        title: '연장근무 수당 미명시',
-        description:
-          '연장근무 시 통상임금의 1.5배 이상을 지급해야 하나, 계약서 내 관련 조항이 없어요.',
-        actionLabel: '신고 방법 보기',
-      },
-      {
-        status: 'warning',
-        law: '근로기준법 제50조',
-        title: '주 52시간 초과 근무 명시',
-        description: '계약서에 주 52시간을 초과한 근무 일정이 기재되어 있어요.',
-        actionLabel: '대응 방법 보기',
-      },
-      {
-        status: 'warning',
-        law: '근로기준법 제55조',
-        title: '주휴일 불명확',
-        description:
-          '주 1회 이상 유급 휴일이 보장되어야 하나, 계약서 내 명시가 불분명해요.',
-        actionLabel: '자세히 보기',
-      },
-      {
-        status: 'normal',
-        law: '최저임금법 제6조',
-        title: '최저임금 기준 충족',
-        description: '계약 시급 ₩ 10,030 - 2026년 최저임금 기준에 충족해요.',
-      },
-    ],
-  },
-  clean: {
-    summaryEyebrow: '분석 완료',
-    summaryTitle: '이상 없어요!',
-    summaryBody: '계약서의 모든 항목이\n한국 노동법 기준에 적합해요.',
-    summaryEmoji: '🎉',
-    variant: 'clean',
-    chips: [{ label: '정상', count: 5, status: 'normal' }],
-    items: [
-      {
-        status: 'normal',
-        law: '근로기준법 제56조',
-        title: '연장 · 야간 · 휴일수당 명시',
-        description: '모든 추가 수당 조항이 계약서에 명확히 기재되어 있어요.',
-      },
-      {
-        status: 'normal',
-        law: '최저임금법 제6조',
-        title: '최저임금 기준 충족',
-        description: '계약 시급 ₩ 10,030 - 2026년 최저임금 기준에 충족해요.',
-      },
-      {
-        status: 'normal',
-        law: '근로기준법 제50조',
-        title: '소정근로시간 적법',
-        description: '주 40시간 이내로 법정 기준에 맞아요.',
-      },
-      {
-        status: 'normal',
-        law: '근로기준법 제50조',
-        title: '주휴일 명시',
-        description: '매주 일요일 유급 휴일로 계약서에 명시되어 있어요.',
-      },
-      {
-        status: 'normal',
-        law: '근로기준법 제17조',
-        title: '계약 필수 항목 모두 포함',
-        description: '임금 · 근로시간 · 업무 내용 등 필수 항목이 모두 기재되어 있어요.',
-      },
-    ],
-  },
-};
+type ResultStatus = 'violation' | 'warning' | 'normal' | 'unknown';
 
 function getStatusPalette(status: ResultStatus) {
   switch (status) {
     case 'violation':
-      return {
-        line: '#EA2F14',
-        badgeBg: '#FFF0EA',
-        badgeText: '#EA2F14',
-        action: '#EA2F14',
-      };
+      return { line: '#EA2F14', badgeBg: '#FFF0EA', badgeText: '#EA2F14', action: '#EA2F14' };
     case 'warning':
-      return {
-        line: '#E57B11',
-        badgeBg: '#FFF4E3',
-        badgeText: '#C56A0B',
-        action: '#E57B11',
-      };
+      return { line: '#E57B11', badgeBg: '#FFF4E3', badgeText: '#C56A0B', action: '#E57B11' };
     case 'normal':
-      return {
-        line: '#1F8E39',
-        badgeBg: '#E8F8EA',
-        badgeText: '#1F8E39',
-        action: '#1F8E39',
-      };
+      return { line: '#1F8E39', badgeBg: '#E8F8EA', badgeText: '#1F8E39', action: '#1F8E39' };
+    case 'unknown':
+      return { line: '#9BA1A6', badgeBg: '#F1F3F5', badgeText: '#687076', action: '#687076' };
   }
 }
 
 function getStatusLabel(status: ResultStatus) {
   switch (status) {
-    case 'violation':
-      return '위반';
-    case 'warning':
-      return '경고';
-    case 'normal':
-      return '정상';
+    case 'violation': return '위반';
+    case 'warning':   return '경고';
+    case 'normal':    return '정상';
+    case 'unknown':   return '확인불가';
   }
 }
 
-function SummaryChip({ chip }: { chip: SummaryChipData }) {
-  const palette = getStatusPalette(chip.status);
-
-  return (
-    <View style={[styles.summaryChip, { backgroundColor: palette.badgeBg }]}>
-      <Text style={[styles.summaryChipText, { color: palette.badgeText }]}>
-        {chip.label} {chip.count}건
-      </Text>
-    </View>
-  );
-}
-
-function ResultSummaryCard({ data }: { data: ResultData }) {
-  const isClean = data.variant === 'clean';
-
-  return (
-    <View style={[styles.summaryCard, isClean ? styles.summaryCardClean : styles.summaryCardIssues]}>
-      <Text style={styles.summaryEyebrow}>{data.summaryEyebrow}</Text>
-      <View style={styles.summaryTitleRow}>
-        <Text style={[styles.summaryTitle, styles.summaryTitleIssues]}>{data.summaryTitle}</Text>
-        {data.summaryEmoji ? <Text style={styles.summaryEmoji}>{data.summaryEmoji}</Text> : null}
-      </View>
-      {data.summaryBody ? <Text style={styles.summaryBody}>{data.summaryBody}</Text> : null}
-      <View style={styles.summaryChipRow}>
-        {data.chips.map((chip) => (
-          <SummaryChip key={`${chip.status}-${chip.label}`} chip={chip} />
-        ))}
-      </View>
-    </View>
-  );
-}
-
-function ResultDetailCard({ item }: { item: DetailItem }) {
-  const palette = getStatusPalette(item.status);
+function ResultDetailCard({ item }: { item: AnalysisItem }) {
+  const status = item.status as ResultStatus;
+  const palette = getStatusPalette(status);
 
   return (
     <View style={[styles.detailCard, { backgroundColor: palette.line }]}>
       <View style={styles.detailCardSurface}>
         <View style={styles.detailCardBody}>
-        <View style={styles.detailHeaderRow}>
-          <View style={[styles.detailStatusBadge, { backgroundColor: palette.badgeBg }]}>
-            <Text style={[styles.detailStatusText, { color: palette.badgeText }]}>
-              {getStatusLabel(item.status)}
-            </Text>
+          <View style={styles.detailHeaderRow}>
+            <View style={[styles.detailStatusBadge, { backgroundColor: palette.badgeBg }]}>
+              <Text style={[styles.detailStatusText, { color: palette.badgeText }]}>
+                {getStatusLabel(status)}
+              </Text>
+            </View>
+            {item.law ? <Text style={styles.detailLaw}>{item.law}</Text> : null}
           </View>
-          <Text style={styles.detailLaw}>{item.law}</Text>
-        </View>
 
-        <Text style={styles.detailTitle}>{item.title}</Text>
-        <Text style={styles.detailDescription}>{item.description}</Text>
+          <Text style={styles.detailTitle}>{item.title}</Text>
+          <Text style={styles.detailDescription}>{item.description}</Text>
 
-        {item.actionLabel ? (
-          <TouchableOpacity activeOpacity={0.8} style={styles.detailAction}>
-            <Text style={[styles.detailActionText, { color: palette.action }]}>{item.actionLabel} →</Text>
-          </TouchableOpacity>
-        ) : null}
+          {item.evidence ? (
+            <Text style={styles.detailEvidence}>📄 {item.evidence}</Text>
+          ) : null}
+
+          {item.actionLabel ? (
+            <TouchableOpacity activeOpacity={0.8} style={styles.detailAction}>
+              <Text style={[styles.detailActionText, { color: palette.action }]}>
+                {item.actionLabel} →
+              </Text>
+            </TouchableOpacity>
+          ) : null}
         </View>
       </View>
     </View>
   );
 }
 
-function FooterCTA() {
-  return (
-    <>
-      <TouchableOpacity style={styles.chatbotCTA} activeOpacity={0.88}>
-        <Ionicons name="chatbubbles-outline" size={28} color="#fff" />
-        <Text style={styles.chatbotCTAText}>챗봇에서 대응 방법 확인하기 →</Text>
-      </TouchableOpacity>
-
-      <View style={styles.disclaimerRow}>
-        <Ionicons name="warning-outline" size={28} color="#8E97A3" />
-        <Text style={styles.disclaimerText}>본 결과는 법률 자문이 아닌 참고용입니다</Text>
-      </View>
-    </>
-  );
-}
-
 export default function ContractResultScreen() {
   const navigation = useNavigation();
-  const params = useLocalSearchParams<{ variant?: string }>();
-  const variant: ResultVariant = params.variant === 'clean' ? 'clean' : 'issues';
-  const data = RESULT_DATA[variant];
-  const handleClose = () => {
-    const parent = navigation.getParent();
+  const result = contractStore.getResult();
+  console.log('[result] contractStore.getResult():', result?.is_clean, '| items:', result?.items?.length);
 
+  const handleClose = () => {
+    contractStore.clear();
+    const parent = navigation.getParent();
     if (parent) {
       parent.dispatch(TabActions.jumpTo('index'));
       return;
     }
-
     router.replace('/');
   };
+
+  if (!result) {
+    return (
+      <ContractLayout step={3} title="결과 확인" rightAction="home"
+        onBack={() => router.replace('/contract')} onRightAction={handleClose}>
+        <View style={styles.emptyWrap}>
+          <Text style={styles.emptyText}>분석 결과가 없어요.</Text>
+          <TouchableOpacity style={styles.retryBtn} onPress={() => router.replace('/contract')}>
+            <Text style={styles.retryBtnText}>다시 시도하기</Text>
+          </TouchableOpacity>
+        </View>
+      </ContractLayout>
+    );
+  }
+
+  const { is_clean, summary, items } = result;
+  const issueCount = summary.violation + summary.warning;
+
+  const summaryTitle = is_clean
+    ? '이상 없어요!'
+    : `위반 ${summary.violation}건\n경고 ${summary.warning}건 발견됐어요`;
 
   return (
     <ContractLayout
@@ -253,206 +109,154 @@ export default function ContractResultScreen() {
       title="결과 확인"
       rightAction="home"
       onBack={() => router.replace('/contract')}
-      onRightAction={handleClose}
-      rightContent={
-        variant === 'issues' ? (
-          <TouchableOpacity
-            activeOpacity={0.8}
-            onPress={() => router.replace('/contract/result?variant=clean')}>
-            <Text style={styles.previewActionText}>정상</Text>
-          </TouchableOpacity>
-        ) : null
-      }>
+      onRightAction={handleClose}>
       <ScrollView
         style={styles.scrollView}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator>
-        <ResultSummaryCard data={data} />
 
+        {/* 요약 카드 */}
+        <View style={[styles.summaryCard, is_clean ? styles.summaryCardClean : styles.summaryCardIssues]}>
+          <Text style={styles.summaryEyebrow}>분석 완료</Text>
+          <View style={styles.summaryTitleRow}>
+            <Text style={styles.summaryTitle}>{summaryTitle}</Text>
+            {is_clean ? <Text style={styles.summaryEmoji}>🎉</Text> : null}
+          </View>
+          {is_clean ? (
+            <Text style={styles.summaryBody}>{'계약서의 모든 항목이\n한국 노동법 기준에 적합해요.'}</Text>
+          ) : null}
+          <View style={styles.summaryChipRow}>
+            {summary.violation > 0 && (
+              <View style={[styles.summaryChip, { backgroundColor: '#FFF0EA' }]}>
+                <Text style={[styles.summaryChipText, { color: '#EA2F14' }]}>위반 {summary.violation}건</Text>
+              </View>
+            )}
+            {summary.warning > 0 && (
+              <View style={[styles.summaryChip, { backgroundColor: '#FFF4E3' }]}>
+                <Text style={[styles.summaryChipText, { color: '#C56A0B' }]}>경고 {summary.warning}건</Text>
+              </View>
+            )}
+            {summary.normal > 0 && (
+              <View style={[styles.summaryChip, { backgroundColor: '#E8F8EA' }]}>
+                <Text style={[styles.summaryChipText, { color: '#1F8E39' }]}>정상 {summary.normal}건</Text>
+              </View>
+            )}
+            {summary.unknown > 0 && (
+              <View style={[styles.summaryChip, { backgroundColor: '#F1F3F5' }]}>
+                <Text style={[styles.summaryChipText, { color: '#687076' }]}>확인불가 {summary.unknown}건</Text>
+              </View>
+            )}
+          </View>
+        </View>
+
+        {/* 항목 카드 */}
         <View style={styles.detailList}>
-          {data.items.map((item) => (
-            <ResultDetailCard key={`${item.status}-${item.title}`} item={item} />
+          {items.map((item) => (
+            <ResultDetailCard key={item.id} item={item} />
           ))}
         </View>
 
-        <FooterCTA />
+        {/* 하단 CTA */}
+        <TouchableOpacity style={styles.chatbotCTA} activeOpacity={0.88}>
+          <Ionicons name="chatbubbles-outline" size={28} color="#fff" />
+          <Text style={styles.chatbotCTAText}>챗봇에서 대응 방법 확인하기 →</Text>
+        </TouchableOpacity>
+
+        <View style={styles.disclaimerRow}>
+          <Ionicons name="warning-outline" size={16} color="#8E97A3" />
+          <Text style={styles.disclaimerText}>본 결과는 법률 자문이 아닌 참고용입니다</Text>
+        </View>
       </ScrollView>
     </ContractLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  scrollView: {
-    flex: 1,
-  },
+  scrollView: { flex: 1 },
   scrollContent: {
     paddingHorizontal: 16,
     paddingTop: 8,
     paddingBottom: 32,
     gap: 12,
   },
+
   summaryCard: {
     borderRadius: 24,
     paddingHorizontal: 20,
     paddingTop: 16,
     paddingBottom: 16,
-    minHeight: 188,
+    minHeight: 160,
   },
-  summaryCardIssues: {
-    backgroundColor: '#1B2028',
-  },
-  summaryCardClean: {
-    backgroundColor: '#1F8E39',
-  },
+  summaryCardIssues: { backgroundColor: '#1B2028' },
+  summaryCardClean: { backgroundColor: '#1F8E39' },
   summaryEyebrow: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: 'rgba(255,255,255,0.72)',
-    marginTop: 4,
-    marginBottom: 8,
+    fontSize: 13, fontWeight: '700',
+    color: 'rgba(255,255,255,0.72)', marginTop: 4, marginBottom: 8,
   },
-  summaryTitleRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: 6,
-  },
+  summaryTitleRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 6 },
   summaryTitle: {
-    flexShrink: 1,
-    fontSize: 26,
-    lineHeight: 33,
-    fontWeight: '800',
-    color: '#fff',
-    letterSpacing: -0.8,
+    flexShrink: 1, fontSize: 28, lineHeight: 36,
+    fontWeight: '800', color: '#fff', letterSpacing: -0.8,
   },
-  summaryTitleIssues: {
-    fontSize: 33,
-    lineHeight: 41,
-    letterSpacing: -1,
-  },
-  summaryEmoji: {
-    fontSize: 26,
-    lineHeight: 33,
-  },
+  summaryEmoji: { fontSize: 26, lineHeight: 33 },
   summaryBody: {
-    marginTop: 6,
-    fontSize: 15,
-    lineHeight: 22,
-    fontWeight: '700',
-    color: 'rgba(255,255,255,0.9)',
+    marginTop: 6, fontSize: 15, lineHeight: 22,
+    fontWeight: '700', color: 'rgba(255,255,255,0.9)',
   },
-  summaryChipRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 8,
-    marginTop: 20,
-  },
-  summaryChip: {
-    borderRadius: 999,
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-  },
-  summaryChipText: {
-    fontSize: 13,
-    fontWeight: '800',
-  },
-  detailList: {
-    gap: 12,
-  },
+  summaryChipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 20 },
+  summaryChip: { borderRadius: 999, paddingHorizontal: 16, paddingVertical: 8 },
+  summaryChipText: { fontSize: 13, fontWeight: '800' },
+
+  detailList: { gap: 12 },
   detailCard: {
-    overflow: 'hidden',
-    borderRadius: 24,
-    shadowColor: '#0F172A',
-    shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.04,
-    shadowRadius: 22,
-    elevation: 2,
+    overflow: 'hidden', borderRadius: 24,
+    shadowColor: '#0F172A', shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.04, shadowRadius: 22, elevation: 2,
   },
-  detailCardSurface: {
-    marginLeft: 4,
-    borderRadius: 20,
-    backgroundColor: '#fff',
-  },
-  detailCardBody: {
-    paddingHorizontal: 18,
-    paddingTop: 18,
-    paddingBottom: 18,
-  },
+  detailCardSurface: { marginLeft: 4, borderRadius: 20, backgroundColor: '#fff' },
+  detailCardBody: { paddingHorizontal: 18, paddingTop: 18, paddingBottom: 18 },
   detailHeaderRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: 12,
+    flexDirection: 'row', alignItems: 'center',
+    justifyContent: 'space-between', gap: 12,
   },
-  detailStatusBadge: {
-    borderRadius: 999,
-    paddingHorizontal: 14,
-    paddingVertical: 7,
-  },
-  detailStatusText: {
-    fontSize: 13,
-    fontWeight: '800',
-  },
+  detailStatusBadge: { borderRadius: 999, paddingHorizontal: 14, paddingVertical: 7 },
+  detailStatusText: { fontSize: 13, fontWeight: '800' },
   detailLaw: {
-    flexShrink: 1,
-    textAlign: 'right',
-    fontSize: 13,
-    fontWeight: '700',
-    color: '#9AA3AE',
+    flexShrink: 1, textAlign: 'right',
+    fontSize: 13, fontWeight: '700', color: '#9AA3AE',
   },
   detailTitle: {
-    marginTop: 14,
-    fontSize: 17,
-    lineHeight: 24,
-    fontWeight: '800',
-    color: '#11181C',
-    letterSpacing: -0.3,
+    marginTop: 14, fontSize: 17, lineHeight: 24,
+    fontWeight: '800', color: '#11181C', letterSpacing: -0.3,
   },
   detailDescription: {
-    marginTop: 10,
-    fontSize: 13,
-    lineHeight: 20,
-    fontWeight: '700',
-    color: '#98A2AE',
+    marginTop: 10, fontSize: 13, lineHeight: 20,
+    fontWeight: '500', color: '#687076',
   },
-  detailAction: {
-    alignSelf: 'flex-start',
-    marginTop: 14,
+  detailEvidence: {
+    marginTop: 8, fontSize: 12, lineHeight: 18,
+    color: '#9BA1A6', fontStyle: 'italic',
   },
-  detailActionText: {
-    fontSize: 15,
-    fontWeight: '800',
-  },
+  detailAction: { alignSelf: 'flex-start', marginTop: 14 },
+  detailActionText: { fontSize: 15, fontWeight: '800' },
+
   chatbotCTA: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 10,
-    marginTop: 4,
-    borderRadius: 22,
-    backgroundColor: '#3D7EF0',
-    paddingVertical: 18,
-    paddingHorizontal: 18,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
+    gap: 10, marginTop: 4, borderRadius: 22, backgroundColor: '#3D7EF0',
+    paddingVertical: 18, paddingHorizontal: 18,
   },
-  chatbotCTAText: {
-    fontSize: 15,
-    fontWeight: '800',
-    color: '#fff',
-  },
+  chatbotCTAText: { fontSize: 15, fontWeight: '800', color: '#fff' },
   disclaimerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    marginTop: 8,
+    flexDirection: 'row', alignItems: 'center',
+    justifyContent: 'center', gap: 8, marginTop: 8,
   },
-  disclaimerText: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: '#8E97A3',
+  disclaimerText: { fontSize: 13, fontWeight: '700', color: '#8E97A3' },
+
+  emptyWrap: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 },
+  emptyText: { fontSize: 16, color: '#687076', fontWeight: '600' },
+  retryBtn: {
+    backgroundColor: '#3182F6', borderRadius: 14,
+    paddingHorizontal: 24, paddingVertical: 14,
   },
-  previewActionText: {
-    fontSize: 15,
-    fontWeight: '700',
-    color: '#1F8E39',
-  },
+  retryBtnText: { color: '#fff', fontSize: 15, fontWeight: '700' },
 });

--- a/workguard-app/app/contract-camera.tsx
+++ b/workguard-app/app/contract-camera.tsx
@@ -3,6 +3,7 @@ import * as ImagePicker from 'expo-image-picker';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { useRef, useState } from 'react';
+import { contractStore } from '@/store/contractStore';
 import {
   Alert,
   Image,
@@ -22,7 +23,6 @@ export default function ContractCameraScreen() {
   const insets = useSafeAreaInsets();
   const [permission, requestPermission] = useCameraPermissions();
   const [images, setImages] = useState<string[]>([]);
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const cameraRef = useRef<CameraView>(null);
 
   async function takePicture() {
@@ -31,7 +31,6 @@ export default function ContractCameraScreen() {
       const photo = await cameraRef.current.takePictureAsync({ quality: 0.8 });
       if (photo?.uri) {
         setImages(prev => [...prev, photo.uri]);
-        setSelectedIndex(null);
       }
     } catch {
       Alert.alert('오류', '사진 촬영에 실패했어요. 다시 시도해 주세요.');
@@ -47,7 +46,6 @@ export default function ContractCameraScreen() {
     });
     if (!result.canceled && result.assets.length > 0) {
       setImages(prev => [...prev, ...result.assets.map(a => a.uri)]);
-      setSelectedIndex(null);
     }
   }
 
@@ -59,7 +57,6 @@ export default function ContractCameraScreen() {
         style: 'destructive',
         onPress: () => {
           setImages(prev => prev.filter((_, i) => i !== index));
-          setSelectedIndex(null);
         },
       },
     ]);
@@ -85,8 +82,6 @@ export default function ContractCameraScreen() {
     );
   }
 
-  const previewUri = selectedIndex !== null ? images[selectedIndex] : null;
-
   return (
     <View style={[styles.container, { paddingTop: insets.top + 8, paddingBottom: insets.bottom + 8 }]}>
 
@@ -99,25 +94,12 @@ export default function ContractCameraScreen() {
       <View style={styles.viewfinder}>
         <CameraView ref={cameraRef} style={StyleSheet.absoluteFill} facing="back" />
 
-        {/* 촬영 이미지 미리보기 오버레이 */}
-        {previewUri && (
-          <View style={[StyleSheet.absoluteFill, styles.previewOverlay]}>
-            <Image source={{ uri: previewUri }} style={StyleSheet.absoluteFill} resizeMode="contain" />
-            <TouchableOpacity style={styles.previewBackBtn} onPress={() => setSelectedIndex(null)}>
-              <Ionicons name="camera-outline" size={16} color="#fff" />
-              <Text style={styles.previewBackText}>카메라로 돌아가기</Text>
-            </TouchableOpacity>
-          </View>
-        )}
-
         {/* 촬영 가이드 */}
-        {!previewUri && (
-          <View style={styles.guideWrap}>
-            <View style={styles.guidePill}>
-              <Text style={styles.guidePillText}>계약서를 프레임 안에 맞춰주세요</Text>
-            </View>
+        <View style={styles.guideWrap}>
+          <View style={styles.guidePill}>
+            <Text style={styles.guidePillText}>문서를 프레임 안에 맞춰주세요</Text>
           </View>
-        )}
+        </View>
 
         {/* 코너 브라켓 */}
         <View style={[styles.corner, styles.cTL]} />
@@ -133,79 +115,38 @@ export default function ContractCameraScreen() {
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
+          style={styles.thumbScroll}
           contentContainerStyle={styles.thumbRow}>
-          {images.map((uri, i) => {
-            const selected = selectedIndex === i;
-            return (
-              <TouchableOpacity
-                key={`${uri}-${i}`}
-                style={[styles.thumb, selected && styles.thumbSelected]}
-                onPress={() => setSelectedIndex(selected ? null : i)}
-                onLongPress={() => deleteImage(i)}>
-                <Image source={{ uri }} style={styles.thumbImage} />
-                {selected && (
-                  <View style={styles.thumbCheck}>
-                    <Ionicons name="checkmark-circle" size={14} color={CORNER_COLOR} />
-                  </View>
-                )}
-                <Text style={[styles.thumbLabel, selected && styles.thumbLabelSelected]}>
-                  {i + 1}p
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
-          <TouchableOpacity style={styles.thumbAdd} onPress={() => setSelectedIndex(null)}>
+          {images.map((uri, i) => (
+            <TouchableOpacity
+              key={`${uri}-${i}`}
+              style={styles.thumb}
+              onLongPress={() => deleteImage(i)}>
+              <Image source={{ uri }} style={styles.thumbImage} />
+              <Text style={styles.thumbLabel}>{i + 1}p</Text>
+            </TouchableOpacity>
+          ))}
+          {/* 다음 페이지 플레이스홀더 */}
+          <View style={styles.thumbPlaceholder}>
+            <Text style={styles.thumbLabel}>{images.length + 1}p</Text>
+          </View>
+          <TouchableOpacity style={styles.thumbAdd} onPress={pickFromGallery}>
             <Ionicons name="add" size={20} color="#9BA1A6" />
           </TouchableOpacity>
         </ScrollView>
 
-        {/* 이전 / 페이지 수 / 다음 */}
-        <View style={styles.pageNav}>
-          <TouchableOpacity
-            style={styles.pageNavBtn}
-            disabled={selectedIndex === null || selectedIndex === 0}
-            onPress={() => selectedIndex !== null && setSelectedIndex(selectedIndex - 1)}>
-            <Ionicons name="chevron-back" size={14} color="#fff" />
-            <Text style={styles.pageNavText}>이전</Text>
-          </TouchableOpacity>
-          <Text>
-            {selectedIndex !== null ? (
-              <>
-                <Text style={styles.pageCountNum}>{selectedIndex + 1}</Text>
-                <Text style={styles.pageCountTotal}> / {images.length} 페이지</Text>
-              </>
-            ) : (
-              <Text style={styles.pageCountTotal}>
-                {images.length > 0 ? `${images.length}장 · 새 페이지 촬영` : '촬영을 시작해 주세요'}
-              </Text>
-            )}
-          </Text>
-          <TouchableOpacity
-            style={styles.pageNavBtn}
-            disabled={selectedIndex === null || selectedIndex >= images.length - 1}
-            onPress={() => selectedIndex !== null && setSelectedIndex(selectedIndex + 1)}>
-            <Text style={styles.pageNavText}>다음</Text>
-            <Ionicons name="chevron-forward" size={14} color="#fff" />
-          </TouchableOpacity>
-        </View>
+        {/* 페이지 카운터 */}
+        <Text style={styles.pageCounter}>
+          <Text style={styles.pageCounterNum}>{images.length + 1}</Text>
+          <Text> / {images.length + 1}페이지</Text>
+        </Text>
 
-        {/* 갤러리 / 촬영 / 파일 */}
+        {/* 촬영 */}
         <View style={styles.actionRow}>
-          <TouchableOpacity style={styles.actionBtn} onPress={pickFromGallery}>
-            <Ionicons name="image-outline" size={26} color="#fff" />
-            <Text style={styles.actionLabel}>갤러리</Text>
-          </TouchableOpacity>
           <TouchableOpacity
-            style={[styles.captureBtn, !!previewUri && styles.captureBtnDisabled]}
-            onPress={previewUri ? undefined : takePicture}
-            disabled={!!previewUri}>
-            <View style={[styles.captureBtnInner, !!previewUri && styles.captureBtnInnerDisabled]} />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={styles.actionBtn}
-            onPress={() => Alert.alert('준비 중이에요', '파일 선택 기능은 곧 추가될 예정이에요.')}>
-            <Ionicons name="document-outline" size={26} color="#fff" />
-            <Text style={styles.actionLabel}>파일</Text>
+            style={styles.captureBtn}
+            onPress={takePicture}>
+            <View style={styles.captureBtnInner} />
           </TouchableOpacity>
         </View>
 
@@ -214,11 +155,16 @@ export default function ContractCameraScreen() {
           style={[styles.ctaBtn, images.length === 0 && styles.ctaBtnDisabled]}
           activeOpacity={0.85}
           disabled={images.length === 0}
-          onPress={() => router.replace('/contract/analyzing')}>
+          onPress={() => {
+            console.log('[camera] CTA 눌림, images.length:', images.length);
+            contractStore.setImages(images);
+            console.log('[camera] setImages 후 getImages():', contractStore.getImages().length);
+            router.replace('/contract/analyzing');
+          }}>
           <Text style={styles.ctaBtnText}>
             {images.length === 0
               ? '사진을 추가해 주세요'
-              : `${images.length}장 완료 · 분석 시작하기 →`}
+              : '촬영 완료 · 분석 시작하기 →'}
           </Text>
         </TouchableOpacity>
 
@@ -283,28 +229,6 @@ const styles = StyleSheet.create({
     borderRadius: 16,
   },
 
-  previewOverlay: {
-    backgroundColor: '#000',
-    borderRadius: 16,
-  },
-  previewBackBtn: {
-    position: 'absolute',
-    bottom: 16,
-    alignSelf: 'center',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    backgroundColor: 'rgba(0,0,0,0.6)',
-    borderRadius: 20,
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-  },
-  previewBackText: {
-    color: '#fff',
-    fontSize: 13,
-    fontWeight: '600',
-  },
-
   guideWrap: {
     ...StyleSheet.absoluteFillObject,
     alignItems: 'center',
@@ -328,7 +252,8 @@ const styles = StyleSheet.create({
   // 하단
   bottomControls: { gap: 12 },
 
-  thumbRow: { gap: 8, alignItems: 'center' },
+  thumbScroll: { height: 72 },
+  thumbRow: { gap: 8, alignItems: 'center', paddingHorizontal: 4 },
   thumb: {
     width: 52,
     height: 64,
@@ -341,12 +266,10 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     padding: 0,
   },
-  thumbSelected: { borderColor: CORNER_COLOR },
   thumbImage: {
     ...StyleSheet.absoluteFillObject,
     borderRadius: 6,
   },
-  thumbCheck: { position: 'absolute', top: 3, right: 3 },
   thumbLabel: {
     fontSize: 10,
     color: '#fff',
@@ -356,7 +279,20 @@ const styles = StyleSheet.create({
     textShadowOffset: { width: 0, height: 1 },
     textShadowRadius: 2,
   },
-  thumbLabelSelected: { color: CORNER_COLOR },
+
+  thumbPlaceholder: {
+    width: 52,
+    height: 64,
+    backgroundColor: '#2C2C2E',
+    borderRadius: 8,
+    borderWidth: 1.5,
+    borderColor: '#636366',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    padding: 0,
+    paddingBottom: 4,
+  },
+
   thumbAdd: {
     width: 52,
     height: 64,
@@ -369,40 +305,21 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 
-  pageNav: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+  pageCounter: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '500',
+    textAlign: 'center',
   },
-  pageNavBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#2C2C2E',
-    borderRadius: 20,
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    gap: 2,
+  pageCounterNum: {
+    color: '#3182F6',
+    fontWeight: '700',
   },
-  pageNavText: { color: '#fff', fontSize: 13, fontWeight: '500' },
-  pageCountNum: { color: CORNER_COLOR, fontWeight: '700', fontSize: 15 },
-  pageCountTotal: { color: '#fff', fontWeight: '500', fontSize: 15 },
 
   actionRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 16,
-  },
-  actionBtn: {
-    width: 64,
-    height: 64,
-    backgroundColor: '#2C2C2E',
-    borderRadius: 16,
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 4,
   },
-  actionLabel: { color: '#9BA1A6', fontSize: 11 },
 
   captureBtn: {
     width: 72,
@@ -413,14 +330,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  captureBtnDisabled: { borderColor: '#3A3A3C', opacity: 0.4 },
   captureBtnInner: {
     width: 56,
     height: 56,
     borderRadius: 28,
     backgroundColor: '#FF3B30',
   },
-  captureBtnInnerDisabled: { backgroundColor: '#636366' },
 
   ctaBtn: {
     backgroundColor: CORNER_COLOR,

--- a/workguard-app/store/contractStore.ts
+++ b/workguard-app/store/contractStore.ts
@@ -1,0 +1,37 @@
+export interface AnalysisItem {
+  id: number;
+  status: 'violation' | 'warning' | 'normal' | 'unknown';
+  law: string | null;
+  title: string;
+  evidence: string | null;
+  description: string;
+  actionLabel: string | null;
+}
+
+export interface AnalysisSummary {
+  violation: number;
+  warning: number;
+  normal: number;
+  unknown: number;
+}
+
+export interface AnalysisResult {
+  is_clean: boolean;
+  summary: AnalysisSummary;
+  items: AnalysisItem[];
+  ocr_text: string;
+  model_used: string;
+  backend_used: string;
+  elapsed_sec: number;
+}
+
+// globalThis 사용: 모듈 재평가(Expo Go 핫 리로드) 후에도 데이터 유지
+const g = globalThis as any;
+
+export const contractStore = {
+  setImages(images: string[]) { g.__wg_images = images; },
+  getImages(): string[] { return g.__wg_images ?? []; },
+  setResult(result: AnalysisResult) { g.__wg_result = result; },
+  getResult(): AnalysisResult | null { return g.__wg_result ?? null; },
+  clear() { g.__wg_images = []; g.__wg_result = null; },
+};

--- a/workguard-server/app/routers/contracts.py
+++ b/workguard-server/app/routers/contracts.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import json
 import logging
+import time
 from typing import Any
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi import APIRouter, File, HTTPException, UploadFile
 from pydantic import BaseModel
-from sqlmodel import Session, select
 
-from app.db.database import get_session
-from app.db.models import ContractAnalysis
 from app.services.analyzer import MODEL_BACKEND, analyze_contract
 from app.services.ocr import OcrError, call_ocr
 from app.services.retriever import retrieve_law_context
@@ -26,8 +23,8 @@ class AnalysisItem(BaseModel):
     law: str | None
     title: str
     evidence: str | None
-    detail: str
-    action: str | None
+    description: str
+    actionLabel: str | None
 
 
 class AnalysisSummary(BaseModel):
@@ -38,7 +35,6 @@ class AnalysisSummary(BaseModel):
 
 
 class AnalyzeResponse(BaseModel):
-    id: str
     is_clean: bool
     summary: AnalysisSummary
     items: list[AnalysisItem]
@@ -48,126 +44,73 @@ class AnalyzeResponse(BaseModel):
     elapsed_sec: float
 
 
-class ContractListItem(BaseModel):
-    id: str
-    created_at: str
-    original_filename: str
-    is_clean: bool
-    violation_count: int
-    warning_count: int
-    normal_count: int
+# ── 정규화 헬퍼 ───────────────────────────────────────────────────────
+
+def _to_response_item(item: dict[str, Any], idx: int) -> AnalysisItem:
+    return AnalysisItem(
+        id=int(item.get("id") or idx),
+        status=str(item.get("status", "unknown")),
+        law=item.get("law"),
+        title=str(item.get("title", "")),
+        evidence=item.get("evidence"),
+        description=str(item.get("description") or item.get("detail") or ""),
+        actionLabel=item.get("actionLabel") if "actionLabel" in item else item.get("action"),
+    )
 
 
 # ── 엔드포인트 ────────────────────────────────────────────────────────
 
 @router.post("/analyze", response_model=AnalyzeResponse)
-def analyze(
-    file: UploadFile = File(...),
-    session: Session = Depends(get_session),
-) -> AnalyzeResponse:
+def analyze(file: UploadFile = File(...)) -> AnalyzeResponse:
     if not file.filename:
         raise HTTPException(status_code=400, detail="파일명이 비어 있습니다.")
 
+    t_total = time.perf_counter()
+
     # 1. OCR
+    t0 = time.perf_counter()
     try:
         ocr_text = call_ocr(file.file, file.filename)
     except OcrError as exc:
         raise HTTPException(status_code=502, detail=f"OCR 실패: {exc}") from exc
     finally:
         file.file.close()
+    logger.info(f"[1/3] OCR 완료 | {time.perf_counter() - t0:.2f}s | {len(ocr_text)}자")
 
     if not ocr_text.strip():
         raise HTTPException(status_code=422, detail="계약서에서 텍스트를 추출할 수 없습니다.")
 
     # 2. RAG
+    t0 = time.perf_counter()
     law_context = retrieve_law_context(ocr_text)
+    logger.info(f"[2/3] RAG 완료 | {time.perf_counter() - t0:.2f}s")
 
     # 3. 분석
+    t0 = time.perf_counter()
     try:
         result = analyze_contract(ocr_text, law_context=law_context)
     except Exception as exc:
         logger.exception("분석 중 오류")
         raise HTTPException(status_code=500, detail=f"분석 실패: {exc}") from exc
+    logger.info(f"[3/3] LLM 분석 완료 | {time.perf_counter() - t0:.2f}s")
 
     meta: dict[str, Any] = result.get("_meta", {})
     summary_raw = result.get("summary", {})
     items_raw = result.get("items", [])
 
-    # 4. SQLite 저장
-    record = ContractAnalysis(
-        original_filename=file.filename,
-        ocr_text=ocr_text,
+    logger.info(f"✅ 완료 | 총 {time.perf_counter() - t_total:.2f}s | is_clean={result.get('is_clean')} | 위반={summary_raw.get('violation')} 경고={summary_raw.get('warning')}")
+
+    return AnalyzeResponse(
         is_clean=result.get("is_clean", False),
-        violation_count=summary_raw.get("violation", 0),
-        warning_count=summary_raw.get("warning", 0),
-        normal_count=summary_raw.get("normal", 0),
-        unknown_count=summary_raw.get("unknown", 0),
-        items_json=json.dumps(items_raw, ensure_ascii=False),
+        summary=AnalysisSummary(
+            violation=summary_raw.get("violation", 0),
+            warning=summary_raw.get("warning", 0),
+            normal=summary_raw.get("normal", 0),
+            unknown=summary_raw.get("unknown", 0),
+        ),
+        items=[_to_response_item(item, idx) for idx, item in enumerate(items_raw, start=1)],
+        ocr_text=ocr_text,
         model_used=meta.get("model", "unknown"),
         backend_used=meta.get("backend", MODEL_BACKEND),
         elapsed_sec=meta.get("elapsed_sec", 0.0),
-    )
-    session.add(record)
-    session.commit()
-    session.refresh(record)
-
-    return AnalyzeResponse(
-        id=record.id,
-        is_clean=record.is_clean,
-        summary=AnalysisSummary(
-            violation=record.violation_count,
-            warning=record.warning_count,
-            normal=record.normal_count,
-            unknown=record.unknown_count,
-        ),
-        items=[AnalysisItem(**item) for item in items_raw],
-        ocr_text=ocr_text,
-        model_used=record.model_used,
-        backend_used=record.backend_used,
-        elapsed_sec=record.elapsed_sec,
-    )
-
-
-@router.get("", response_model=list[ContractListItem])
-def list_contracts(session: Session = Depends(get_session)) -> list[ContractListItem]:
-    records = session.exec(
-        select(ContractAnalysis).order_by(ContractAnalysis.created_at.desc())
-    ).all()
-    return [
-        ContractListItem(
-            id=r.id,
-            created_at=r.created_at.isoformat(),
-            original_filename=r.original_filename,
-            is_clean=r.is_clean,
-            violation_count=r.violation_count,
-            warning_count=r.warning_count,
-            normal_count=r.normal_count,
-        )
-        for r in records
-    ]
-
-
-@router.get("/{contract_id}", response_model=AnalyzeResponse)
-def get_contract(
-    contract_id: str,
-    session: Session = Depends(get_session),
-) -> AnalyzeResponse:
-    record = session.get(ContractAnalysis, contract_id)
-    if not record:
-        raise HTTPException(status_code=404, detail="분석 결과를 찾을 수 없습니다.")
-
-    return AnalyzeResponse(
-        id=record.id,
-        is_clean=record.is_clean,
-        summary=AnalysisSummary(
-            violation=record.violation_count,
-            warning=record.warning_count,
-            normal=record.normal_count,
-            unknown=record.unknown_count,
-        ),
-        items=[AnalysisItem(**item) for item in record.items],
-        ocr_text=record.ocr_text,
-        model_used=record.model_used,
-        backend_used=record.backend_used,
-        elapsed_sec=record.elapsed_sec,
     )

--- a/workguard-server/app/services/analyzer.py
+++ b/workguard-server/app/services/analyzer.py
@@ -11,17 +11,30 @@ from app.prompt import SYSTEM_PROMPT, build_user_prompt
 
 logger = logging.getLogger(__name__)
 
-# MODEL_BACKEND=mlx  → Apple Silicon MLX (기본)
-# MODEL_BACKEND=gguf → llama-cpp-python GGUF
-MODEL_BACKEND = os.getenv("MODEL_BACKEND", "mlx")
+MODEL_BACKEND = os.getenv("MODEL_BACKEND", "ollama")
 
 MLX_MODEL = os.getenv("MLX_MODEL", "mlx-community/gemma-4-e4b-it-4bit")
 GGUF_MODEL_PATH = os.getenv("GGUF_MODEL_PATH", "./models/model.gguf")
 GGUF_N_CTX = int(os.getenv("GGUF_N_CTX", "8192"))
-GGUF_N_GPU_LAYERS = int(os.getenv("GGUF_N_GPU_LAYERS", "-1"))  # -1 = 전부 GPU
+GGUF_N_GPU_LAYERS = int(os.getenv("GGUF_N_GPU_LAYERS", "-1"))
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "gemma4:e4b")
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+OLLAMA_OPTIONS = {"temperature": 0, "top_p": 0.8, "num_predict": 4096}
 
 _mlx_cache: dict[str, tuple] = {}
 _gguf_cache: dict[str, Any] = {}
+
+STATUSES = {"위반", "경고", "정상", "확인불가", "violation", "warning", "normal", "unknown"}
+STATUS_TO_REPORT = {
+    "위반": "violation", "경고": "warning", "정상": "normal", "확인불가": "unknown",
+    "violation": "violation", "warning": "warning", "normal": "normal", "unknown": "unknown",
+}
+ACTION_BY_STATUS = {
+    "violation": "신고 방법 보기", "warning": "대응 방법 보기",
+    "normal": None, "unknown": "확인 요청하기",
+    "위반": "신고 방법 보기", "경고": "대응 방법 보기",
+    "정상": None, "확인불가": "확인 요청하기",
+}
 
 
 # ── JSON 파싱 유틸 ────────────────────────────────────────────────────
@@ -32,13 +45,16 @@ def _fix_json(text: str) -> str:
     return text
 
 
+def _strip_fences(text: str) -> str:
+    return re.sub(r"^```(?:json)?\s*|\s*```$", "", text.strip(), flags=re.DOTALL).strip()
+
+
 def _parse_json(raw: str) -> dict[str, Any]:
-    for candidate in [
-        raw.strip(),
-        re.search(r"```(?:json)?\s*(\{.*?\})\s*```", raw, re.DOTALL),
-        re.search(r"\{.*\}", raw, re.DOTALL),
-    ]:
-        text = candidate.group(1) if hasattr(candidate, "group") else candidate
+    stripped = _strip_fences(raw)
+    for candidate in [stripped, re.search(r"\{.*\}", stripped, re.DOTALL)]:
+        if candidate is None:
+            continue
+        text = candidate.group(0) if hasattr(candidate, "group") else candidate
         if not text:
             continue
         try:
@@ -48,15 +64,190 @@ def _parse_json(raw: str) -> dict[str, Any]:
     raise ValueError(f"JSON을 파싱할 수 없습니다: {raw[:300]}")
 
 
+# ── 정규화 ────────────────────────────────────────────────────────────
+
+def _normalize_analysis(result: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(result, dict):
+        raise ValueError("분석 결과는 JSON object여야 합니다.")
+
+    items = result.get("items")
+    if not isinstance(items, list) or not items:
+        raise ValueError("분석 결과가 예상 JSON 형식이 아닙니다.")
+
+    normalized_items: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        raw_status = str(item.get("status", "")).strip()
+        if raw_status not in STATUSES:
+            continue
+        status = STATUS_TO_REPORT[raw_status]
+        title = str(item.get("title", "")).strip()
+        description = str(item.get("description") or item.get("detail") or "").strip()
+        if not title or not description:
+            continue
+        law = item.get("law")
+        evidence = item.get("evidence")
+        normalized_items.append({
+            "id": len(normalized_items) + 1,
+            "status": status,
+            "law": law if law not in ("", "null", "None") else None,
+            "title": title,
+            "evidence": evidence if evidence not in ("", "null", "None") else None,
+            "description": description,
+            "actionLabel": ACTION_BY_STATUS[status],
+        })
+
+    if not normalized_items:
+        raise ValueError("유효한 판정 항목이 없습니다.")
+    if len(normalized_items) != 10:
+        raise ValueError(f"items는 10개여야 합니다: {len(normalized_items)}개")
+
+    counts = {
+        "violation": sum(1 for i in normalized_items if i["status"] == "violation"),
+        "warning":   sum(1 for i in normalized_items if i["status"] == "warning"),
+        "normal":    sum(1 for i in normalized_items if i["status"] == "normal"),
+        "unknown":   sum(1 for i in normalized_items if i["status"] == "unknown"),
+    }
+    return {
+        "is_clean": counts["violation"] == 0 and counts["warning"] == 0,
+        "summary": counts,
+        "items": normalized_items,
+    }
+
+
+# ── Fallback (LLM 실패 시 규칙 기반) ─────────────────────────────────
+
+def _amounts(text: str) -> list[int]:
+    amounts: list[int] = []
+    for match in re.finditer(r"(\d[\d,]*)\s*원", text):
+        try:
+            amounts.append(int(match.group(1).replace(",", "")))
+        except ValueError:
+            continue
+    return amounts
+
+def _has_any(text: str, words: tuple[str, ...]) -> bool:
+    return any(word in text for word in words)
+
+def _find_money_evidence(text: str, keywords: tuple[str, ...]) -> tuple[int | None, str | None]:
+    for match in re.finditer(r"[^.\n]{0,40}?(\d[\d,]*)\s*원[^.\n]{0,20}", text):
+        evidence = match.group(0).strip()
+        if any(k in evidence for k in keywords):
+            try:
+                return int(match.group(1).replace(",", "")), evidence
+            except ValueError:
+                continue
+    return None, None
+
+def _is_missing_near(text: str, keyword: str, window: int = 30) -> bool:
+    for match in re.finditer(re.escape(keyword), text):
+        start = max(0, match.start() - window)
+        end = min(len(text), match.end() + window)
+        if _has_any(text[start:end], ("미기재", "명시되지 않음", "내용 없음", "없음", "null")):
+            return True
+    return False
+
+def _evidence_near(text: str, keywords: tuple[str, ...], window: int = 55) -> str | None:
+    for keyword in keywords:
+        match = re.search(re.escape(keyword), text)
+        if match:
+            start = max(0, match.start() - window)
+            end = min(len(text), match.end() + window)
+            return text[start:end].strip(" .,\n\t")
+    return None
+
+def _fallback_analysis(contract_text: str, reason: str) -> dict[str, Any]:
+    logger.warning(f"LLM JSON 형식 복구 실패, fallback 분석 사용: {reason}")
+    text = re.sub(r"\s+", " ", contract_text)
+    amounts = _amounts(text)
+
+    def item(id_: int, status: str, law: str | None, title: str,
+             evidence: str | None, description: str) -> dict[str, Any]:
+        return {"id": id_, "status": status, "law": law, "title": title,
+                "evidence": evidence, "description": description,
+                "actionLabel": ACTION_BY_STATUS[status]}
+
+    monthly_wage, monthly_evidence = _find_money_evidence(
+        text, ("월급", "월 임금", "월임금", "월급여", "기본급", "월(일", "임금"))
+    hourly_wage, hourly_evidence = _find_money_evidence(text, ("시급", "시간급"))
+    if monthly_wage is None and _has_any(text, ("월급", "기본급", "임금")) and amounts:
+        monthly_wage = max(amounts)
+        monthly_evidence = _evidence_near(text, ("월급", "임금", f"{monthly_wage:,}원")) or f"{monthly_wage:,}원"
+    if hourly_wage is None and _has_any(text, ("시급",)) and amounts:
+        hourly_wage = min(amounts)
+        hourly_evidence = _evidence_near(text, ("시급", f"{hourly_wage:,}원")) or f"{hourly_wage:,}원"
+
+    items: list[dict[str, Any]] = []
+
+    period_ev = _evidence_near(text, ("근로계약기간", "계약기간", "부터", "까지"))
+    items.append(item(1, "normal" if period_ev else "warning", None, "근로계약 기간", period_ev,
+        "근로계약 기간 관련 문구가 확인됩니다." if period_ev else "근로계약 기간이 명확하지 않아 보완이 필요합니다."))
+
+    duty_ev = _evidence_near(text, ("업무장소", "근무장소", "업무내용", "담당업무"))
+    items.append(item(2, "normal" if duty_ev else "warning", "근로기준법 시행령 제8조", "업무 내용 및 근무 장소", duty_ev,
+        "업무 내용과 근무 장소가 확인됩니다." if duty_ev else "업무 내용 또는 근무 장소가 명확하지 않습니다."))
+
+    time_ev = _evidence_near(text, ("근로시간", "근무시간", "휴게시간"))
+    items.append(item(3, "normal" if time_ev and _has_any(text, ("휴게",)) else "warning",
+        "근로기준법 제50·53조", "근로일, 근로시간, 휴게시간", time_ev,
+        "근로시간과 휴게시간이 확인됩니다." if time_ev else "근로시간 또는 휴게시간이 명확하지 않습니다."))
+
+    if monthly_wage is not None:
+        ws = "violation" if monthly_wage < 2_096_270 else "normal"
+        wd = f"명시된 월급 {monthly_wage:,}원은 2026년 최저임금 기준 월 2,096,270원{'에 미달합니다' if ws == 'violation' else ' 이상입니다'}."
+        we = monthly_evidence
+    elif hourly_wage is not None:
+        ws = "violation" if hourly_wage < 10_030 else "normal"
+        wd = f"명시된 시급 {hourly_wage:,}원은 2026년 최저임금 기준 시급 10,030원{'에 미달합니다' if ws == 'violation' else ' 이상입니다'}."
+        we = hourly_evidence
+    else:
+        ws, wd, we = "warning", "임금 금액이 명확히 확인되지 않아 최저임금 충족 여부를 판단할 수 없습니다.", None
+    items.append(item(4, ws, "최저임금법 제6조", "임금 구성, 금액, 산정 기준", we, wd))
+
+    pay_ev = _evidence_near(text, ("지급일", "매월", "계좌", "이체"))
+    items.append(item(5, "normal" if pay_ev else "warning", "근로기준법 제43조", "임금 지급일, 지급 방법", pay_ev,
+        "임금 지급일 또는 지급 방법이 확인됩니다." if pay_ev else "임금 지급일 또는 지급 방법이 명확하지 않습니다."))
+
+    leave_ev = _evidence_near(text, ("주휴", "연차", "유급휴가"))
+    items.append(item(6, "normal" if leave_ev else "unknown", "근로기준법 제55·60조", "휴일, 주휴일, 연차유급휴가", leave_ev,
+        "휴일 또는 연차유급휴가 관련 문구가 확인됩니다." if leave_ev else "휴일, 주휴일 또는 연차 관련 내용이 없어 판단할 수 없습니다."))
+
+    ot_ev = _evidence_near(text, ("연장", "야간", "휴일근로", "가산수당", "포괄임금"))
+    if ot_ev and _has_any(ot_ev, ("미지급", "없음")):
+        ot_s = "violation"
+    elif ot_ev:
+        ot_s = "warning" if _has_any(ot_ev, ("고정", "포괄")) else "normal"
+    else:
+        ot_s = "unknown"
+    items.append(item(7, ot_s, "근로기준법 제56조", "연장·야간·휴일근로 및 가산수당", ot_ev,
+        "가산수당 미지급 조항은 법 위반 소지가 있습니다." if ot_s == "violation" else
+        "고정 수당으로 법정 기준 충족 여부 확인이 필요합니다." if ot_s == "warning" else
+        "가산수당 지급 기준이 확인됩니다." if ot_s == "normal" else "가산수당 관련 내용이 없어 판단할 수 없습니다."))
+
+    ret_ev = _evidence_near(text, ("퇴직금", "퇴직급여"))
+    items.append(item(8, "normal" if ret_ev else "unknown", "근로자퇴직급여 보장법 제8조", "퇴직금/퇴직급여", ret_ev,
+        "퇴직금 관련 문구가 확인됩니다." if ret_ev else "퇴직금 관련 내용이 없어 판단할 수 없습니다."))
+
+    term_ev = _evidence_near(text, ("해고", "퇴직", "계약 해지", "30일 전"))
+    items.append(item(9, "normal" if term_ev else "unknown", "근로기준법 제26조", "계약 해지, 퇴직, 해고예고", term_ev,
+        "해고예고 관련 문구가 확인됩니다." if term_ev else "해고예고 관련 내용이 없어 판단할 수 없습니다."))
+
+    dmg_ev = _evidence_near(text, ("위약금", "손해배상", "임금에서 공제"))
+    items.append(item(10, "violation" if dmg_ev else "normal", "근로기준법 제20조", "손해배상, 위약금, 임금 공제", dmg_ev,
+        "손해배상 예정 또는 임금 공제 조항이 확인되어 법 위반 소지가 있습니다." if dmg_ev else
+        "손해배상 예정, 위약금 또는 임금 공제 조항은 확인되지 않습니다."))
+
+    return _normalize_analysis({"items": items})
+
+
 # ── MLX 백엔드 ────────────────────────────────────────────────────────
 
 def _mlx_analyze(contract_text: str, law_context: str) -> tuple[str, str]:
     from mlx_lm import generate, load
-
     if MLX_MODEL not in _mlx_cache:
         logger.info(f"MLX 모델 로딩: {MLX_MODEL}")
         _mlx_cache[MLX_MODEL] = load(MLX_MODEL)
-
     model, tokenizer = _mlx_cache[MLX_MODEL]
     messages = [
         {"role": "system", "content": SYSTEM_PROMPT},
@@ -71,53 +262,69 @@ def _mlx_analyze(contract_text: str, law_context: str) -> tuple[str, str]:
 
 def _gguf_analyze(contract_text: str, law_context: str) -> tuple[str, str]:
     from llama_cpp import Llama
-
     if GGUF_MODEL_PATH not in _gguf_cache:
         if not os.path.exists(GGUF_MODEL_PATH):
-            raise FileNotFoundError(
-                f"GGUF 모델 파일을 찾을 수 없습니다: {GGUF_MODEL_PATH}\n"
-                "GGUF_MODEL_PATH 환경변수를 확인하거나 모델 파일을 다운로드하세요."
-            )
+            raise FileNotFoundError(f"GGUF 모델 파일을 찾을 수 없습니다: {GGUF_MODEL_PATH}")
         logger.info(f"GGUF 모델 로딩: {GGUF_MODEL_PATH}")
-        _gguf_cache[GGUF_MODEL_PATH] = Llama(
-            model_path=GGUF_MODEL_PATH,
-            n_ctx=GGUF_N_CTX,
-            n_gpu_layers=GGUF_N_GPU_LAYERS,
-            verbose=False,
-        )
-
+        _gguf_cache[GGUF_MODEL_PATH] = Llama(model_path=GGUF_MODEL_PATH,
+            n_ctx=GGUF_N_CTX, n_gpu_layers=GGUF_N_GPU_LAYERS, verbose=False)
     llm = _gguf_cache[GGUF_MODEL_PATH]
     response = llm.create_chat_completion(
-        messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": build_user_prompt(contract_text, law_context)},
-        ],
-        max_tokens=4096,
-        temperature=0.1,
-    )
-    raw = response["choices"][0]["message"]["content"]
-    return raw, os.path.basename(GGUF_MODEL_PATH)
+        messages=[{"role": "system", "content": SYSTEM_PROMPT},
+                  {"role": "user", "content": build_user_prompt(contract_text, law_context)}],
+        max_tokens=4096, temperature=0.1)
+    return response["choices"][0]["message"]["content"], os.path.basename(GGUF_MODEL_PATH)
+
+
+# ── Ollama 백엔드 ─────────────────────────────────────────────────────
+
+def _ollama_chat(messages: list[dict], use_json_format: bool = True) -> str:
+    import requests
+    payload: dict = {"model": OLLAMA_MODEL, "messages": messages, "stream": False, "options": OLLAMA_OPTIONS}
+    if use_json_format:
+        payload["format"] = "json"
+    logger.info(f"Ollama 호출 | model={OLLAMA_MODEL} | json_format={use_json_format}")
+    response = requests.post(f"{OLLAMA_BASE_URL}/api/chat", json=payload, timeout=300)
+    response.raise_for_status()
+    return response.json()["message"]["content"]
+
+def _ollama_analyze(contract_text: str, law_context: str) -> tuple[str, str]:
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": build_user_prompt(contract_text, law_context)},
+    ]
+    raw = _ollama_chat(messages)
+    logger.info(f"Ollama 응답:\n{raw}")
+    return raw, OLLAMA_MODEL
+
+def _ollama_retry_analyze(contract_text: str, law_context: str, error: str) -> tuple[str, str]:
+    logger.warning(f"Ollama 응답 형식 오류로 재시도: {error}")
+    system = SYSTEM_PROMPT + """
+
+중요: 최상위 키는 is_clean, summary, items 입니다.
+items 내부 키는 id, status, law, title, evidence, description, actionLabel 입니다.
+JSON 외 텍스트, 마크다운, 코드블록을 출력하지 마세요."""
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": build_user_prompt(contract_text, law_context)},
+    ]
+    raw = _ollama_chat(messages)
+    logger.info(f"Ollama 재시도 응답:\n{raw}")
+    return raw, f"{OLLAMA_MODEL}:retry"
 
 
 # ── 공통 진입점 ───────────────────────────────────────────────────────
 
-def analyze_contract(
-    contract_text: str,
-    law_context: str = "",
-) -> dict[str, Any]:
-    """
-    계약서 텍스트를 LLM으로 분석한다.
-    MODEL_BACKEND 환경변수로 mlx / gguf 선택.
-    """
+def analyze_contract(contract_text: str, law_context: str = "") -> dict[str, Any]:
     truncated = contract_text[:4000]
     start = time.perf_counter()
 
-    logger.info(
-        f"분석 시작 | backend={MODEL_BACKEND} | text_len={len(truncated)} | rag={'yes' if law_context else 'no'}"
-    )
+    logger.info(f"분석 시작 | backend={MODEL_BACKEND} | text_len={len(truncated)} | rag={'yes' if law_context else 'no'}")
 
     if MODEL_BACKEND == "gguf":
         raw, model_id = _gguf_analyze(truncated, law_context)
+    elif MODEL_BACKEND == "ollama":
+        raw, model_id = _ollama_analyze(truncated, law_context)
     else:
         raw, model_id = _mlx_analyze(truncated, law_context)
 
@@ -127,10 +334,19 @@ def analyze_contract(
     if not raw.strip():
         raise ValueError("모델이 빈 응답을 반환했습니다.")
 
-    result = _parse_json(raw)
-    result["_meta"] = {
-        "backend": MODEL_BACKEND,
-        "model": model_id,
-        "elapsed_sec": elapsed,
-    }
+    try:
+        result = _normalize_analysis(_parse_json(raw))
+    except ValueError as exc:
+        if MODEL_BACKEND == "ollama":
+            raw, model_id = _ollama_retry_analyze(truncated, law_context, str(exc))
+            try:
+                result = _normalize_analysis(_parse_json(raw))
+            except ValueError as retry_exc:
+                model_id = f"{model_id}:fallback"
+                result = _fallback_analysis(truncated, str(retry_exc))
+        else:
+            result = _fallback_analysis(truncated, str(exc))
+
+    logger.info(f"파싱 결과:\n{json.dumps(result, ensure_ascii=False, indent=2)}")
+    result["_meta"] = {"backend": MODEL_BACKEND, "model": model_id, "elapsed_sec": elapsed}
     return result


### PR DESCRIPTION
## 개요
계약서 분석 플로우(갤러리 선택 → 분석 → 결과)가 끊겨 있던 문제들을 수정했습니다.

## 문제 및 수정 내용

### 🐛 이미지가 분석 화면에 전달되지 않음
- `contract/index.tsx` 갤러리 선택 후 `contractStore.setImages()` 호출 없이 analyzing으로 이동
- → 갤러리 선택 시 이미지 URI를 store에 저장하도록 수정

### 🐛 결과 화면에서 항상 "분석 결과가 없어요" 표시
- `contractStore`의 모듈 레벨 변수(`let _result = null`)가 Expo Go 환경에서 재평가 시 초기화됨
- → `globalThis` 기반으로 변경하여 화면 이동 후에도 데이터 유지

### 🐛 실제 폰에서 서버 연결 실패 (Network request failed)
- `.env`의 `EXPO_PUBLIC_API_URL`이 `localhost`로 고정되어 있어 폰에서 접근 불가
- → Mac 로컬 IP로 변경

### ✨ 카메라 화면 + 버튼 기능 연결
- `+` 버튼이 `() => {}` 빈 함수로 되어 있어 갤러리 연결 안 됨
- → `pickFromGallery` 연결

### ✨ 분석 중 화면 페이지 수 동적 표시
- 하드코딩된 "7페이지" → 실제 이미지 개수로 표시

### ✨ 서버 분석 결과 실제 연동
- `analyzing.tsx` 애니메이션만 돌고 mock 데이터 사용하던 것을 실제 API 호출로 교체
- `result.tsx` hardcoded 데이터 → `contractStore`에서 실제 결과 읽어 표시
- `workguard-server` analyzer, contracts 라우터 정규화 로직 추가

## 관련 이슈
close #57