### PR TITLE
fix: 급여 캘린더 UI 텍스트 스타일 통일

### DIFF
--- a/workguard-app/app/(tabs)/salary-calendar/[date].tsx
+++ b/workguard-app/app/(tabs)/salary-calendar/[date].tsx
@@ -476,8 +476,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
     paddingHorizontal: 20, marginTop: 20, marginBottom: 10,
   },
-  sectionTitleBlue: { fontSize: 14, fontWeight: '700', fontStyle: 'italic', color: Brand.primary, letterSpacing: 0.5 },
-  sectionTitleDark: { fontSize: 14, fontWeight: '700', color: '#11181C', letterSpacing: 0.5 },
+  sectionTitleBlue: { fontSize: 16, fontWeight: '700', color: Brand.primary, letterSpacing: 0.5 },
+  sectionTitleDark: { fontSize: 16, fontWeight: '700', color: Brand.primary, letterSpacing: 0.5 },
   sectionSubtitle: { fontSize: 13, color: '#9BA1A6' },
 
   card: {

--- a/workguard-app/app/(tabs)/salary-calendar/index.tsx
+++ b/workguard-app/app/(tabs)/salary-calendar/index.tsx
@@ -271,7 +271,7 @@ const styles = StyleSheet.create({
   },
   amountSub: {
     fontSize: 14,
-    color: Brand.primary,
+    color: '#11181C',
     marginTop: 2,
   },
 


### PR DESCRIPTION
## 📜 개요
급여 캘린더 내 텍스트 스타일 불일치 문제를 수정합니다.

## 🔧 변경 사항

### 근무 내역 상세 화면 (`[date].tsx`)
- `WORK TIME` 텍스트: 이탤릭 제거, fontSize 14 → 16
- `OVER TIME` 텍스트: 색상 검정 → 파란색(Brand.primary), fontSize 14 → 16
- 두 텍스트 스타일을 파란색 + 일반체 + 16px로 통일

### 급여 캘린더 메인 (`index.tsx`)
- `expected per month` 텍스트 색상: 파란색(Brand.primary) → 검정색(#11181C)

## 💡 관련 이슈
closes #59
