### PR TITLE
feat: 계약서 분석 결과 → 챗봇 연동 및 chat API 구현 (#60)

### DIFF
--- a/workguard-app/app/(tabs)/contract/result.tsx
+++ b/workguard-app/app/(tabs)/contract/result.tsx
@@ -3,6 +3,10 @@ import { router } from 'expo-router';
 import { TabActions, useNavigation } from '@react-navigation/native';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
+function goToChat(message: string) {
+  router.push({ pathname: '/chatbot/chat' as any, params: { initialMessage: message } });
+}
+
 import { ContractLayout } from '@/components/contract/contract-layout';
 import { contractStore, type AnalysisItem } from '@/store/contractStore';
 
@@ -55,7 +59,12 @@ function ResultDetailCard({ item }: { item: AnalysisItem }) {
           ) : null}
 
           {item.actionLabel ? (
-            <TouchableOpacity activeOpacity={0.8} style={styles.detailAction}>
+            <TouchableOpacity
+              activeOpacity={0.8}
+              style={styles.detailAction}
+              onPress={() => goToChat(
+                `[${getStatusLabel(status)}] ${item.title}\n\n${item.description}${item.law ? '\n\n관련 법령: ' + item.law : ''}`
+              )}>
               <Text style={[styles.detailActionText, { color: palette.action }]}>
                 {item.actionLabel} →
               </Text>
@@ -157,7 +166,15 @@ export default function ContractResultScreen() {
         </View>
 
         {/* 하단 CTA */}
-        <TouchableOpacity style={styles.chatbotCTA} activeOpacity={0.88}>
+        <TouchableOpacity
+          style={styles.chatbotCTA}
+          activeOpacity={0.88}
+          onPress={() => {
+            const itemSummary = result.items
+              .map(item => `[${getStatusLabel(item.status as ResultStatus)}] ${item.title}\n${item.description}${item.law ? ` (${item.law})` : ''}`)
+              .join('\n\n');
+            goToChat(`계약서 분석 결과입니다.\n\n${itemSummary}\n\n위 내용을 바탕으로 대응 방법을 알려주세요.`);
+          }}>
           <Ionicons name="chatbubbles-outline" size={28} color="#fff" />
           <Text style={styles.chatbotCTAText}>챗봇에서 대응 방법 확인하기 →</Text>
         </TouchableOpacity>

--- a/workguard-app/app/chatbot/chat.tsx
+++ b/workguard-app/app/chatbot/chat.tsx
@@ -1,7 +1,8 @@
 import { Ionicons } from '@expo/vector-icons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
+  ActivityIndicator,
   FlatList,
   KeyboardAvoidingView,
   Platform,
@@ -15,31 +16,83 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Brand } from '@/constants/theme';
 
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
+
 type Message =
   | { id: string; type: 'user' | 'bot'; text: string }
   | { id: string; type: 'analysis'; text: string }
-  | { id: string; type: 'quick-reply' };
+  | { id: string; type: 'quick-reply' }
+  | { id: string; type: 'loading' };
 
-const QUICK_REPLIES = ['Show me the law', "Calculate what I'm owed", '...'];
-
-const INITIAL_MESSAGES: Message[] = [
-  { id: '1', type: 'bot', text: 'Hello! Ask me anything about working in Korea.' },
-  { id: '2', type: 'user', text: 'Can you check my contract?' },
-  { id: '3', type: 'analysis', text: 'I checked your contract. There are some issues you should be aware of regarding your working hours and overtime pay.' },
-  { id: '4', type: 'quick-reply' },
-];
+const BOT_HELLO = '안녕하세요! 한국 노동법에 관해 무엇이든 물어보세요.';
 
 export default function ChatScreen() {
-  const { category } = useLocalSearchParams<{ category?: string }>();
-  const [messages, setMessages] = useState<Message[]>(INITIAL_MESSAGES);
+  const { category, initialMessage } = useLocalSearchParams<{ category?: string; initialMessage?: string }>();
+
+  const startMessages: Message[] = initialMessage
+    ? [
+        { id: '1', type: 'bot', text: BOT_HELLO },
+        { id: '2', type: 'user', text: initialMessage },
+      ]
+    : [{ id: '1', type: 'bot', text: BOT_HELLO }];
+
+  const [messages, setMessages] = useState<Message[]>(startMessages);
   const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
   const flatListRef = useRef<FlatList>(null);
 
+  // initialMessage가 있으면 자동으로 봇 응답 요청
+  useEffect(() => {
+    console.log('[chat] initialMessage:', initialMessage);
+    console.log('[chat] API_BASE_URL:', API_BASE_URL);
+    if (initialMessage) {
+      fetchBotReply([{ role: 'user' as const, content: initialMessage }]);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function fetchBotReply(history: { role: 'user' | 'assistant'; content: string }[]) {
+    setLoading(true);
+    const loadingId = `loading-${Date.now()}`;
+    setMessages(prev => [...prev, { id: loadingId, type: 'loading' }]);
+    try {
+      const res = await fetch(`${API_BASE_URL}/chat/message`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: history }),
+      });
+      const data = await res.json();
+      const reply = data.reply ?? '응답을 가져오지 못했어요.';
+      setMessages(prev => [
+        ...prev.filter(m => m.id !== loadingId),
+        { id: Date.now().toString(), type: 'bot', text: reply },
+      ]);
+    } catch (err: any) {
+      console.error('[chat] fetchBotReply 오류:', err?.message, err);
+      setMessages(prev => [
+        ...prev.filter(m => m.id !== loadingId),
+        { id: Date.now().toString(), type: 'bot', text: '서버에 연결할 수 없어요. 잠시 후 다시 시도해 주세요.' },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   function sendMessage(text: string) {
-    if (!text.trim()) return;
-    const userMsg: Message = { id: Date.now().toString(), type: 'user', text: text.trim() };
+    if (!text.trim() || loading) return;
+    const trimmed = text.trim();
+    const userMsg: Message = { id: Date.now().toString(), type: 'user', text: trimmed };
     setMessages(prev => [...prev, userMsg]);
     setInput('');
+
+    // 현재 대화 히스토리 구성
+    const history = [...messages, userMsg]
+      .filter((m): m is { id: string; type: 'user' | 'bot'; text: string } =>
+        m.type === 'user' || m.type === 'bot'
+      )
+      .map(m => ({ role: (m.type === 'user' ? 'user' : 'assistant') as 'user' | 'assistant', content: m.text }));
+
+    fetchBotReply(history);
   }
 
   function renderItem({ item }: { item: Message }) {
@@ -73,19 +126,18 @@ export default function ChatScreen() {
       );
     }
 
-    if (item.type === 'quick-reply') {
+    if (item.type === 'loading') {
       return (
-        <View style={styles.quickReplyRow}>
-          {QUICK_REPLIES.map(label => (
-            <TouchableOpacity
-              key={label}
-              style={styles.quickReplyBtn}
-              onPress={() => label === '...' ? router.push('/chatbot/get-help' as any) : sendMessage(label)}>
-              <Text style={styles.quickReplyText}>{label}</Text>
-            </TouchableOpacity>
-          ))}
+        <View style={styles.rowLeft}>
+          <View style={styles.bubbleBot}>
+            <ActivityIndicator size="small" color="#9BA1A6" />
+          </View>
         </View>
       );
+    }
+
+    if (item.type === 'quick-reply') {
+      return null;
     }
 
     return null;
@@ -128,7 +180,10 @@ export default function ChatScreen() {
             onSubmitEditing={() => sendMessage(input)}
             returnKeyType="send"
           />
-          <TouchableOpacity style={styles.sendButton} onPress={() => sendMessage(input)}>
+          <TouchableOpacity
+            style={[styles.sendButton, loading && { opacity: 0.5 }]}
+            onPress={() => sendMessage(input)}
+            disabled={loading}>
             <Ionicons name="arrow-up" size={18} color="#fff" />
           </TouchableOpacity>
         </View>

--- a/workguard-server/app/routers/chat.py
+++ b/workguard-server/app/routers/chat.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Literal
+
+import httpx
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "gemma4:e4b")
+
+CHAT_SYSTEM_PROMPT = """당신은 한국 노동법 전문 상담 AI입니다.
+사용자가 근로계약서 분석 결과를 바탕으로 질문하면, 한국 노동법 기준으로 친절하고 명확하게 답변해 주세요.
+- 관련 법령을 구체적으로 언급해 주세요 (예: 근로기준법 제00조)
+- 실질적인 대응 방법을 알려주세요
+- 모르는 내용은 솔직하게 모른다고 하세요
+- 답변은 한국어로 해주세요"""
+
+
+class ChatMessage(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
+
+
+class ChatRequest(BaseModel):
+    messages: list[ChatMessage]
+
+
+class ChatResponse(BaseModel):
+    reply: str
+
+
+@router.post("/message", response_model=ChatResponse)
+def chat(req: ChatRequest) -> ChatResponse:
+    logger.info(f"[chat] 요청 수신 | 메시지 {len(req.messages)}개 | 마지막: {req.messages[-1].content[:50] if req.messages else '-'}")
+    messages = [{"role": "system", "content": CHAT_SYSTEM_PROMPT}]
+    messages += [{"role": m.role, "content": m.content} for m in req.messages]
+
+    try:
+        res = httpx.post(
+            f"{OLLAMA_BASE_URL}/api/chat",
+            json={"model": OLLAMA_MODEL, "messages": messages, "stream": False,
+                  "options": {"temperature": 0.7, "num_predict": 1024}},
+            timeout=60,
+        )
+        res.raise_for_status()
+        reply = res.json()["message"]["content"]
+        logger.info(f"[chat] LLM 응답:\n{reply}")
+        return ChatResponse(reply=reply)
+    except Exception as exc:
+        logger.exception("챗봇 응답 오류")
+        raise HTTPException(status_code=500, detail=f"챗봇 오류: {exc}") from exc

--- a/workguard-server/main.py
+++ b/workguard-server/main.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import logging
 from contextlib import asynccontextmanager
 
+from dotenv import load_dotenv
+load_dotenv()
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.db.database import init_db
+from app.routers.chat import router as chat_router
 from app.routers.contracts import router as contracts_router
 from app.routers.work_logs import router as work_logs_router
 from app.services.retriever import ensure_collection
@@ -36,6 +40,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(chat_router)
 app.include_router(contracts_router)
 app.include_router(work_logs_router)
 


### PR DESCRIPTION
## 🔨 작업 내용
계약서 분석 결과와 챗봇을 연결하는 프론트엔드 흐름 구현 및 chat API 신규 구성
## ✨ 구현 사항
### 프론트엔드
- 결과 카드 버튼 → 해당 항목 내용(제목, 설명, 법령)을 첫 메시지로 챗봇 이동
- 하단 CTA → 전체 분석 항목 요약을 첫 메시지로 챗봇 이동
- initialMessage 수신 시 자동으로 LLM 응답 요청
- 로딩 말풍선, 전송 버튼 비활성화 처리
- 대화 히스토리 누적 전달
### 백엔드
- `POST /chat/message` 엔드포인트 신규 구현
- 시스템 프롬프트: 한국 노동법 전문 상담 AI
- 대화 히스토리 + 시스템 프롬프트를 Ollama(gemma4:e4b)에 전달
- 요청/응답 전체 로깅
- python-dotenv 추가로 .env 자동 로드
close #60