### PR TITLE
feat: 달력 색상 변경 및 스케줄 목록 현재 주 기준 표시

### DIFF
--- a/workguard-app/app/(tabs)/salary-calendar/index.tsx
+++ b/workguard-app/app/(tabs)/salary-calendar/index.tsx
@@ -43,8 +43,8 @@ function buildWeeks(year: number, month: number): (number | null)[][] {
 }
 
 const DAY_COLORS: Record<DayType, string> = {
-  work: '#FFE4E4',
-  overtime: '#FEF3C7',
+  work: '#DCFCE7',
+  overtime: '#FFE4E4',
 };
 
 const MAX_HOURS = 9;
@@ -81,13 +81,18 @@ export default function SalaryCalendarScreen() {
     dayTypeMap[day] = log.overtime_hours > 0 ? 'overtime' : 'work';
   });
 
-  // 이번 달 전체 날짜 기반으로 스케줄 생성
-  const daysInMonth = new Date(year, month, 0).getDate();
-  const scheduleItems: ScheduleItem[] = Array.from({ length: daysInMonth }, (_, i) => {
-    const date = i + 1;
-    const dayOfWeek = new Date(year, month - 1, date).getDay();
+  // 현재 날짜가 포함된 주(일~토) 7일 스케줄 생성
+  const todayDow = today.getDay();
+  const weekStart = new Date(today);
+  weekStart.setDate(today.getDate() - todayDow);
+  const scheduleItems: ScheduleItem[] = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(weekStart);
+    d.setDate(weekStart.getDate() + i);
+    const date = d.getDate();
+    const dayOfWeek = d.getDay();
     const dayName = WEEK_DAYS[dayOfWeek];
-    const log = workLogs.find((l) => parseInt(l.log_date.split('-')[2], 10) === date);
+    const logDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(date).padStart(2, '0')}`;
+    const log = workLogs.find((l) => l.log_date === logDate);
     if (log && log.start_time && log.end_time) {
       const [sh, sm] = log.start_time.split(':').map(Number);
       const [eh, em] = log.end_time.split(':').map(Number);


### PR DESCRIPTION
## 📜 개요
달력 색상 스킴을 변경하고, 스케줄 목록을 현재 주 기준으로 표시하도록 개선합니다.

## 🔧 변경 사항

### 달력 색상 변경
- work: 빨간색 → 초록색(`#DCFCE7`)
- overtime: 노란색 → 빨간색(`#FFE4E4`)

### 스케줄 목록 현재 주 기준 표시
- 기존: 이번 달 전체 날짜 표시
- 변경: 현재 날짜가 포함된 주(일~토) 7일만 표시

## 💡 관련 이슈
closes #67
