### PR TITLE
fix: 근무 등록 페이지 기본값 수정

### DIFF
--- a/workguard-app/app/(tabs)/salary-calendar/[date].tsx
+++ b/workguard-app/app/(tabs)/salary-calendar/[date].tsx
@@ -201,9 +201,9 @@ export default function DayDetailScreen() {
   const minWheelRef = useRef<WheelRef>(null);
 
   // 기타 상태
-  const [overtime, setOvertime] = useState(2.5);
+  const [overtime, setOvertime] = useState(0);
   const [nightShift, setNightShift] = useState(false);
-  const [holidayWork, setHolidayWork] = useState(true);
+  const [holidayWork, setHolidayWork] = useState(false);
   const [logId, setLogId] = useState<string | null>(null);
   const [fee, setFee] = useState<number | null>(null);
 


### PR DESCRIPTION
## 📜 개요
근무 등록 페이지의 잘못된 기본값을 수정합니다.

## 🔧 변경 사항
- overtime 슬라이더 기본값: `2.5` → `0`
- holiday work 토글 기본값: `true` → `false`

## 💡 관련 이슈
closes #69
