### PR TITLE
feat: 예상 월급 동적 계산 및 fee 미등록 알림

### DIFF
--- a/workguard-app/app/(tabs)/salary-calendar/[date].tsx
+++ b/workguard-app/app/(tabs)/salary-calendar/[date].tsx
@@ -301,7 +301,7 @@ export default function DayDetailScreen() {
           <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
             <Ionicons name="chevron-back" size={22} color="#11181C" />
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>4/{dateStr}</Text>
+          <Text style={styles.headerTitle}>{month}/{dateStr}</Text>
           <View style={styles.headerSpacer} />
         </View>
 

--- a/workguard-app/app/(tabs)/salary-calendar/index.tsx
+++ b/workguard-app/app/(tabs)/salary-calendar/index.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect, useRouter } from 'expo-router';
-import { useCallback, useState } from 'react';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useCallback, useEffect, useState } from 'react';
+import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { API_BASE_URL } from '@/constants/api';
@@ -16,6 +16,7 @@ type WorkLog = {
   log_date: string;
   start_time: string | null;
   end_time: string | null;
+  fee: number | null;
   overtime_hours: number;
   is_night_shift: boolean;
   is_holiday_work: boolean;
@@ -74,9 +75,13 @@ export default function SalaryCalendarScreen() {
     }, [year, month]),
   );
 
-  // API 데이터로 달력 색상 결정
+  // API 데이터로 달력 색상 결정 (실제 근무 시간이 있는 경우만 색상 표시)
   const dayTypeMap: Record<number, DayType> = {};
   workLogs.forEach((log) => {
+    if (!log.start_time || !log.end_time) return;
+    const [sh, sm] = log.start_time.split(':').map(Number);
+    const [eh, em] = log.end_time.split(':').map(Number);
+    if ((eh * 60 + em) - (sh * 60 + sm) <= 0) return;
     const day = parseInt(log.log_date.split('-')[2], 10);
     dayTypeMap[day] = log.overtime_hours > 0 ? 'overtime' : 'work';
   });
@@ -104,6 +109,16 @@ export default function SalaryCalendarScreen() {
     return { day: dayName, date, hasWork: false, timeRange: '', hours: 0 };
   });
 
+  const totalFee = workLogs.reduce((sum, log) => sum + (log.fee ?? 0), 0);
+  const hasFee = workLogs.some((l) => l.fee != null && l.fee > 0);
+  const hasWorkedDays = scheduleItems.some((item) => item.hasWork);
+
+  useEffect(() => {
+    if (hasWorkedDays && !hasFee) {
+      Alert.alert('급여 정보 없음', '등록된 일당(fee) 정보가 없습니다.\n근무 내역에서 급여를 등록해주세요.');
+    }
+  }, [workLogs]);
+
   const handleDayPress = (day: number) => {
     router.push(`/(tabs)/salary-calendar/${day}`);
   };
@@ -121,7 +136,7 @@ export default function SalaryCalendarScreen() {
         </View>
 
         <View style={styles.amountSection}>
-          <Text style={styles.amount}>₩1,842,000</Text>
+          <Text style={styles.amount}>{hasFee ? `₩${totalFee.toLocaleString()}` : '-'}</Text>
           <Text style={styles.amountSub}>expected per month</Text>
         </View>
 


### PR DESCRIPTION
## 📜 개요
하드코딩된 예상 월급을 실제 등록된 fee 합산으로 동적 계산하고, 관련 버그를 함께 수정합니다.

## 🔧 변경 사항

### 예상 월급 동적 계산 (`index.tsx`)
- 이번 달 workLogs의 fee 합산으로 계산
- fee 미등록 시 `-` 표시
- 실제 근무일이 있는데 fee가 하나도 없으면 알림 표시

### 버그 수정
- 시작/종료 시간이 동일한 경우(0시간 근무) 달력에 색상이 표시되던 문제 수정
- 근무 상세 화면 헤더 월이 `4/`로 하드코딩되어 있던 문제 수정 → 현재 월로 동적 표시 (`[date].tsx`)

## 💡 관련 이슈
closes #71
