### PR TITLE
feat: 앱 API URL GCP 서버 연결

### DIFF
--- a/workguard-app/constants/api.ts
+++ b/workguard-app/constants/api.ts
@@ -1,4 +1,7 @@
 import Constants from 'expo-constants';
 
 const localhost = Constants.expoConfig?.hostUri?.split(':')[0] ?? 'localhost';
-export const API_BASE_URL = `http://${localhost}:8000`;
+
+export const API_BASE_URL = __DEV__
+  ? `http://${localhost}:8000`
+  : 'http://34.50.8.14:8000';


### PR DESCRIPTION
## 📜 개요
앱의 API 요청이 개발 환경에서는 로컬 서버, 프로덕션 빌드에서는 GCP 서버로 연결되도록 분기합니다.

## 🔧 변경 사항

### API URL 환경별 분기 (`constants/api.ts`)
- 개발 빌드(`__DEV__ = true`): 기존 로컬 서버 (`http://<localhost>:8000`)
- 프로덕션 빌드(`__DEV__ = false`): GCP 서버 (`http://34.50.8.14:8000`)

## 💡 관련 이슈
closes #75