### PR TITLE
fix: API_BASE_URL 하드코딩 제거 및 constants/api.ts로 통일

### DIFF
--- a/workguard-app/app/(tabs)/contract/analyzing.tsx
+++ b/workguard-app/app/(tabs)/contract/analyzing.tsx
@@ -4,8 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Animated, Easing, StyleSheet, Text, View } from 'react-native';
 import { contractStore } from '@/store/contractStore';
 
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
-
+import { API_BASE_URL } from '@/constants/api';
 import { ContractLayout } from '@/components/contract/contract-layout';
 
 type StepStatus = 'completed' | 'active' | 'pending';

--- a/workguard-app/app/chatbot/chat.tsx
+++ b/workguard-app/app/chatbot/chat.tsx
@@ -15,8 +15,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Brand } from '@/constants/theme';
-
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
+import { API_BASE_URL } from '@/constants/api';
 
 type Message =
   | { id: string; type: 'user' | 'bot'; text: string }


### PR DESCRIPTION
## 📜 개요
각 화면에 하드코딩된 API URL을 `constants/api.ts`의 `API_BASE_URL`로 통일합니다.

## 🔧 변경 사항

### `analyzing.tsx`
- `process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000'` 제거
- `API_BASE_URL` import로 교체

### `chat.tsx`
- `process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000'` 제거
- `API_BASE_URL` import로 교체

## 💡 관련 이슈
closes #77